### PR TITLE
Query evaluation optimisations

### DIFF
--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/util/Debug.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/util/Debug.kt
@@ -1,0 +1,24 @@
+package dev.tesserakt.sparql.runtime.common.util
+
+object Debug {
+
+    data class State(
+        var arrayBackedJoin: Int = 0,
+    )
+
+    fun reset() {
+        state = State()
+    }
+
+    fun report() = buildString {
+        appendLine("Debug information")
+        appendLine("\tArray-backed pattern joins: ${state.arrayBackedJoin}")
+    }
+
+    private var state = State()
+
+    internal fun onArrayPatternJoinExecuted() {
+        state.arrayBackedJoin += 1
+    }
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/HashJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/HashJoinArray.kt
@@ -1,0 +1,166 @@
+package dev.tesserakt.sparql.runtime.incremental.state
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.core.Mapping
+
+/**
+ * An array useful for storing a series of mappings, capable of joining with other mappings using the hash join
+ *  algorithm. Hash tables are created for every binding name passed in the constructor.
+ */
+class HashJoinArray(bindings: Collection<String>) {
+
+    // the backing structure, contains all mappings ever received
+    private val backing = mutableListOf<Mapping>()
+    // the underlying hash table, mapping the binding name to the map that indexes it on its value, followed by a list
+    //  of indices that should be used in the array above - reason for the use of indices is so evaluating multiple
+    //  binding constraints only relies on comparing numbers to compare & merge the total resulting set
+    // --
+    // the positional indices (`ArrayList<Int>`) is guaranteed to be sorted: see the various insertion implementations;
+    //  this further allows efficient lookup of multiple constraints at the same time
+    private val index = buildMap<String, MutableMap<Quad.Term, ArrayList<Int>>>(capacity = bindings.size) {
+        bindings.forEach { binding ->
+            put(binding, mutableMapOf())
+        }
+    }
+
+    init {
+        check(bindings.isNotEmpty()) { "Invalid use of hash join array! No bindings are used!" }
+    }
+
+    /**
+     * Adds a mapping to the backing array and indexes it accordingly.
+     *
+     * IMPORTANT: the keys of the mapping should exactly match the binding names used to construct this join array!
+     */
+    fun add(mapping: Mapping) {
+        val pos = backing.size
+        backing.add(mapping)
+        mapping.forEach { (binding, value) ->
+            index[binding]!!.getOrPut(value) { arrayListOf() }.add(pos)
+        }
+    }
+
+    /**
+     * Adds all mappings to the backing array and indexes it accordingly.
+     *
+     * IMPORTANT: the keys of every mapping should exactly match the binding names used to construct this join array!
+     */
+    fun addAll(mappings: List<Mapping>) {
+        if (mappings.isEmpty()) {
+            return
+        }
+        val start = backing.size
+        backing.addAll(mappings)
+        mappings.first().forEach { (binding, value) ->
+            index[binding]!!
+                .getOrPut(value) { arrayListOf() }
+                .also { it.ensureCapacity(it.size + mappings.size) }
+                .add(start)
+        }
+        (1 ..< mappings.size).forEach { i ->
+            mappings[i].forEach { (binding, value) ->
+                index[binding]!![value]!!.add(start + i)
+            }
+        }
+    }
+
+    fun join(other: List<Mapping>): List<Mapping> {
+        val compatible = getCompatibleMappings(other)
+        return compatible.indices.flatMap { i -> compatible[i].map { it + other[i] } }
+    }
+
+    /**
+     * Returns a list of all compatible mappings using the provided reference mappings.
+     */
+    private fun getCompatibleMappings(references: List<Mapping>): List<List<Mapping>> {
+        // separating the individual references into their constraints
+        val constraints: Map<Mapping, List<Int>> = references.indices.groupBy { i ->
+            val current = references[i]
+            val constraints = current.keys.filter { it in index }.toSet()
+            current.filter { it.key in constraints }
+        }
+        // with all relevant & unique constraints formed, the compatible mappings w/o redundant lookup can be retrieved
+        val mapped = constraints.map { (constraints, indexes) -> getCompatibleMappings(constraints) to indexes }
+        // now the map can be "exploded" again into its original form
+        return mapped
+            .flatMapTo(ArrayList(references.size)) { entry -> entry.second.map { i -> i to entry.first } }
+            .sortedBy { it.first }
+            .map { it.second }
+    }
+
+    /**
+     * Returns a list of mappings compatible with the provided mapping
+     */
+    private fun getCompatibleMappings(reference: Mapping): List<Mapping> {
+        val constraints = reference.keys.filter { it in index }
+        // if there aren't any constraints, all mappings (the entire backing array) can be returned instead
+        if (constraints.isEmpty()) {
+            return backing
+        }
+        // getting all relevant indexes - if any of the mapping's values don't have an ID list present for the reference's
+        //  value, we can bail early: none match the reference
+        val indexes = constraints.map { index[it]!![reference[it]!!] ?: return emptyList() }
+        // the resulting array cannot be longer than the smallest index found, so if any of them are empty, no results
+        //  are found
+        if (indexes.any { it.isEmpty() }) {
+            return emptyList()
+        }
+        // these index arrays are guaranteed to be sorted already (see other notes), so "quickMerge"ing them and mapping
+        //  these indexes to their actual value
+        return quickMerge(indexes).map { backing[it] }
+    }
+
+    companion object {
+
+        /**
+         * Merges the provided [indices] together to a single index list, only containing items found in all entries.
+         *  The size of the result never exceeds the size of the smallest index list passed as argument. The method
+         *  assumes all individual index lists to be distinct and sorted in ascending order.
+         */
+        // example: [0, 1, 2] & [2] -> [2]
+        private fun quickMerge(indices: List<List<Int>>): List<Int> {
+            var result = indices.first()
+            var i = indices.size - 1
+            while (i > 0) {
+                if (result.isEmpty()) {
+                    return emptyList()
+                }
+                result = quickMerge(result, indices[i])
+                --i
+            }
+            return result
+        }
+
+        /**
+         * Merges the two provided indices [left] and [right] together to a single index list, only containing items
+         *  found in both entries. The size of the result never exceeds the size of the smallest index list passed as
+         *  an argument. The method assumes the individual index lists to be distinct and sorted in ascending order.
+         */
+        // example: [0, 1, 2] & [2] -> [2]
+        private fun quickMerge(left: List<Int>, right: List<Int>): List<Int> {
+            var i = 0
+            var j = 0
+            val result = ArrayList<Int>(minOf(left.size, right.size))
+            while (i < left.size && j < right.size) {
+                val a = left[i]
+                val b = right[j]
+                when {
+                    a == b -> {
+                        result.add(a)
+                        ++i
+                        ++j
+                    }
+                    a < b -> {
+                        ++i
+                    }
+                    b < a -> {
+                        ++j
+                    }
+                }
+            }
+            return result
+        }
+
+    }
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -8,6 +8,8 @@ import dev.tesserakt.sparql.runtime.util.Bitmask
 
 internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
 
+//    private val patternCache = MappingCache.Full()
+//    private val patternCache = MappingCache.None
     private val patternCache = MappingCache.ChainStart()
     private val unionCache = MappingCache.ChainStart()
     private val patterns = ast.patterns.map { it.createIncrementalPatternState() }
@@ -92,6 +94,47 @@ internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
                 }
             }
             .let { patterns.fold(it) { results, p -> p.join(results) } }
+
+        // FIXME: this doesn't work: maybe offload the single pattern results also in the cache,
+        //  and let the cache-specific method deal with the trickling down of all new sub-states;
+        //  the cache API then also would solely have to deal with all possible return values for a single pattern
+        //  group
+//        with (patternCache) {
+//            patterns
+//                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = patterns.size) to pattern.delta(quad) }
+//                .expandResultSet()
+//                .growUsingCache()
+//                .flatMap { (mask, mappings) ->
+//                    // as we only need to iterate over the patterns not yet managed, we need to inverse the bitmask
+//                    //  before iterating over it
+//                    var currentMask = mask
+//                    mask.inv().fold(mappings) { results, i ->
+//                        val result = patterns[i].join(results)
+//                        currentMask = currentMask.withOnesAt(i)
+//                        patternCache.insert(currentMask, result)
+//                        result
+//                    }
+//                }
+//        }
+//        // updating the plan union-wise
+//        with (unionCache) {
+//            unions
+//                .mapIndexed { i, union -> Bitmask.onesAt(i, length = unions.size) to union.delta(quad) }
+//                .expandResultSet()
+//                .growUsingCache()
+//                .flatMap { (mask, mappings) ->
+//                    // as we only need to iterate over the unions not yet managed, we need to inverse the bitmask
+//                    //  before iterating over it
+//                    var currentMask = mask
+//                    mask.inv().fold(mappings) { results, i ->
+//                        val result = unions[i].join(results)
+//                        currentMask = currentMask.withOnesAt(i)
+//                        unionCache.insert(currentMask, result)
+//                        result
+//                    }
+//                }
+//                .let { patterns.fold(it) { results, p -> p.join(results) } }
+//        }
     }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -8,10 +8,20 @@ import dev.tesserakt.sparql.runtime.util.Bitmask
 
 internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
 
+    private val patternCache = MappingCache.SingleChainLeft()
+    private val unionCache = MappingCache.SingleChainLeft()
     private val patterns = ast.patterns.map { it.createIncrementalPatternState() }
     private val unions = ast.unions.map { union -> IncrementalUnionState(union) }
 
     fun delta(quad: Quad): List<Mapping> {
+        // TODO:
+        //  * run the pattern delta for the new quad
+        //  * expand the result set
+        //  * get all cached pattern states
+        //  * grow the cached results with the individual pattern deltas based on compatible masks
+        //    (i.e. delta 0b100 is compatible with cache results from 0b001, 0b010 and 0b011, where present)
+        //  * grow all other not-part-of-cache results that can still create complete results
+        //    (i.e. delta 0b010 can still yield results if mask 0b101 is not part of cached states)
         val base = patterns
             .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = patterns.size) to pattern.delta(quad) }
             .expandResultSet()
@@ -39,11 +49,51 @@ internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
     }
 
     fun insert(quad: Quad) {
+        // first updating the cache before individual child states are altered so the delta calculations are correct
+        updateCache(quad)
+        // now the child states can also insert the quad
         patterns.forEach { it.insert(quad) }
         unions.forEach { it.insert(quad) }
     }
 
     fun join(mappings: List<Mapping>): List<Mapping> = unions
         .fold(initial = patterns.fold(mappings) { results, p -> p.join(results) }) { results, u -> u.join(results) }
+
+    // TODO: overhaul this state's API so delta + insertion can be done in a single call, which can then also
+    //  reduce the # of "delta processing" required
+    // TODO: may also benefit from the same original cache use as noted by the original "delta" above
+    private fun updateCache(quad: Quad) {
+        // updating the cache pattern-wise
+        patterns
+            .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = patterns.size) to pattern.delta(quad) }
+            .expandResultSet()
+            .flatMap { (mask, mappings) ->
+                // as we only need to iterate over the patterns not yet managed, we need to inverse the bitmask
+                //  before iterating over it
+                var currentMask = mask
+                mask.inv().fold(mappings) { results, i ->
+                    val result = patterns[i].join(results)
+                    currentMask = currentMask.withOnesAt(i)
+                    patternCache.insert(currentMask, result)
+                    result
+                }
+            }
+        // updating the plan union-wise
+        unions
+            .mapIndexed { i, union -> Bitmask.onesAt(i, length = unions.size) to union.delta(quad) }
+            .expandResultSet()
+            .flatMap { (mask, mappings) ->
+                // as we only need to iterate over the unions not yet managed, we need to inverse the bitmask
+                //  before iterating over it
+                var currentMask = mask
+                mask.inv().fold(mappings) { results, i ->
+                    val result = unions[i].join(results)
+                    currentMask = currentMask.withOnesAt(i)
+                    unionCache.insert(currentMask, result)
+                    result
+                }
+            }
+            .let { patterns.fold(it) { results, p -> p.join(results) } }
+    }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
@@ -9,7 +9,6 @@ import dev.tesserakt.sparql.runtime.core.pattern.bindingName
 import dev.tesserakt.sparql.runtime.core.pattern.matches
 import dev.tesserakt.sparql.runtime.incremental.types.SegmentsList
 import dev.tesserakt.sparql.runtime.util.Bitmask
-import dev.tesserakt.util.compatibleWith
 
 internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate> {
 
@@ -22,16 +21,7 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate> {
             data.addAll(delta(quad))
         }
 
-        final override fun join(mappings: List<Mapping>): List<Mapping> = mappings.flatMap { bindings ->
-            data.mapNotNull { previous ->
-                // checking to see if there's any incompatibility in the input constraints
-                if (bindings.compatibleWith(previous)) {
-                    bindings + previous
-                } else {
-                    null
-                }
-            }
-        }
+        final override fun join(mappings: List<Mapping>): List<Mapping> = mergeCompatibleMappings(data, mappings)
 
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.types.Pattern
+import dev.tesserakt.sparql.runtime.common.util.Debug
 import dev.tesserakt.sparql.runtime.common.util.getTermOrNull
 import dev.tesserakt.sparql.runtime.core.Mapping
 import dev.tesserakt.sparql.runtime.core.mappingOf
@@ -21,7 +22,10 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate> {
             data.addAll(delta(quad))
         }
 
-        final override fun join(mappings: List<Mapping>): List<Mapping> = mergeCompatibleMappings(data, mappings)
+        final override fun join(mappings: List<Mapping>): List<Mapping> {
+            Debug.onArrayPatternJoinExecuted()
+            return mergeCompatibleMappings(data, mappings)
+        }
 
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
@@ -24,7 +24,7 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate> {
 
         final override fun join(mappings: List<Mapping>): List<Mapping> {
             Debug.onArrayPatternJoinExecuted()
-            return mergeCompatibleMappings(data, mappings)
+            return doNestedJoin(data, mappings)
         }
 
     }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
@@ -4,15 +4,14 @@ import dev.tesserakt.sparql.runtime.core.Mapping
 import dev.tesserakt.sparql.runtime.util.Bitmask
 
 /**
- * A general mapping cache type, capable of caching a series of mappings with their corresponding "completion" bitmasks
- *  according to internal (cache-specific) rules
+ * A general join tree type, containing intermediate joined values depending on the tree implementation
  */
-sealed class MappingCache {
+sealed class JoinTree {
 
     /**
-     * A naive caching approach, not actually caching any intermediate results
+     * Non-existent join tree
      */
-    data object None: MappingCache() {
+    data object None: JoinTree() {
 
         override fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
             // nothing to save, we don't cache anything
@@ -24,9 +23,9 @@ sealed class MappingCache {
     }
 
     /**
-     * A naive caching approach, caching every variant possible
+     * Caches all intermediate joined values, does not behave as an actual tree.
      */
-    class Full: MappingCache() {
+    class Full: JoinTree() {
 
         private val cache = mutableMapOf<Bitmask, MutableList<Mapping>>()
 
@@ -58,7 +57,7 @@ sealed class MappingCache {
      * A caching strategy only keeping intermediate mapping results cached that form a single chain starting from the
      *  very first element.
      */
-    class ChainStart: MappingCache() {
+    class LeftDeep: JoinTree() {
 
         private val cache = mutableListOf<MutableList<Mapping>?>()
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MappingCache.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MappingCache.kt
@@ -1,0 +1,52 @@
+package dev.tesserakt.sparql.runtime.incremental.state
+
+import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.util.Bitmask
+
+/**
+ * A general mapping cache type, capable of caching a series of mappings with their corresponding "completion" bitmasks
+ *  according to internal (cache-specific) rules
+ */
+sealed class MappingCache {
+
+    /**
+     * A naive caching approach, not actually caching any intermediate results
+     */
+    data object None: MappingCache() {
+
+        override fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
+            // nothing to save, we don't cache anything
+        }
+
+    }
+
+    /**
+     * A caching strategy only keeping intermediate mapping results cached that form a single chain starting from the
+     *  very first element.
+     */
+    class SingleChainLeft: MappingCache() {
+
+        private val cache = mutableMapOf<Bitmask, MutableList<Mapping>>()
+
+        override fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
+            // only saving those for which only a > 1 chain of LSBs are set (i.e. accepting 0b011, but not 0b010)
+            //  but not those that are completely satisfied (complete solutions) as these can't be joined further
+            val satisfied = bitmask.count()
+            if (
+                satisfied <= 1 ||
+                bitmask.size() == satisfied ||
+                bitmask.lowestZeroBitIndex() < bitmask.highestOneBitIndex()
+            ) {
+                return
+            }
+            cache.getOrPut(bitmask) { mutableListOf() }.addAll(mappings)
+        }
+
+    }
+
+    /**
+     * Processes the provided [mappings] associated with the satisfied [bitmask] for plan-based optimal caching
+     */
+    abstract fun insert(bitmask: Bitmask, mappings: List<Mapping>)
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MappingCache.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MappingCache.kt
@@ -45,7 +45,7 @@ sealed class MappingCache {
                 val cached = cache[remaining]
                 val satisfied = Bitmask.wrap(raw = (1 shl (mask.size() + 1)) - 1, length = mask.size())
                 if (cached != null) {
-                    satisfied to mergeCompatibleMappings(cached, mappings)
+                    satisfied to doNestedJoin(cached, mappings)
                 } else {
                     mask to mappings
                 }
@@ -101,7 +101,7 @@ sealed class MappingCache {
                 val cached = cache.getOrNull(index)
                     // wasn't cached (no valid combination found thus far)
                     ?: return@map mask to mappings
-                val result = mergeCompatibleMappings(cached, mappings)
+                val result = doNestedJoin(cached, mappings)
                 // forming the new mask this result adheres to, which is
                 //  the original mask | ones (index based length)
                 val satisfied = Bitmask.wrap((1 shl (index + 2)) - 1, length = mask.size())

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -37,3 +37,11 @@ internal inline fun List<Pair<Bitmask, List<Mapping>>>.expandResultSet(): List<P
     }
     return result
 }
+
+internal inline fun mergeCompatibleMappings(a: List<Mapping>, b: List<Mapping>) = buildList(a.size + b.size) {
+    a.forEach { left ->
+        b.forEach { right ->
+            if (left.compatibleWith(right)) add(left + right)
+        }
+    }
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -1,6 +1,8 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
+import dev.tesserakt.sparql.runtime.common.types.Pattern
 import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.core.pattern.bindingName
 import dev.tesserakt.sparql.runtime.util.Bitmask
 import dev.tesserakt.util.compatibleWith
 
@@ -45,3 +47,9 @@ internal inline fun doNestedJoin(a: List<Mapping>, b: List<Mapping>) = buildList
         }
     }
 }
+
+internal inline fun bindingNamesOf(
+    subject: Pattern.Subject,
+    predicate: Pattern.Predicate,
+    `object`: Pattern.Object
+): List<String> = listOfNotNull(subject.bindingName, predicate.bindingName, `object`.bindingName)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -38,7 +38,7 @@ internal inline fun List<Pair<Bitmask, List<Mapping>>>.expandResultSet(): List<P
     return result
 }
 
-internal inline fun mergeCompatibleMappings(a: List<Mapping>, b: List<Mapping>) = buildList(a.size + b.size) {
+internal inline fun doNestedJoin(a: List<Mapping>, b: List<Mapping>) = buildList(a.size + b.size) {
     a.forEach { left ->
         b.forEach { right ->
             if (left.compatibleWith(right)) add(left + right)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Bitmask.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Bitmask.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.runtime.util
 
 class Bitmask private constructor(
     private val bits: Int,
-    private val length: Int
+    val length: Int
 ): Iterable<Int> {
 
     operator fun get(index: Int) = ((bits shr index) and 1) == 1
@@ -49,6 +49,8 @@ class Bitmask private constructor(
             }
             return Bitmask(bits = result, length = booleans.size)
         }
+
+        fun wrap(raw: Int, length: Int): Bitmask = Bitmask(bits = raw, length = length)
 
         fun onesAt(index: Int, length: Int? = null): Bitmask {
             val result = 1 shl index
@@ -127,7 +129,7 @@ class Bitmask private constructor(
      *
      * Example: `0b1010` returns 3
      */
-    fun highestOneBitIndex() = Int.SIZE_BITS - bits.countLeadingZeroBits()
+    fun highestOneBitIndex() = Int.SIZE_BITS - bits.countLeadingZeroBits() - 1
 
     /**
      * Returns the index of the highest zero bit.

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Bitmask.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Bitmask.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.runtime.util
 
 class Bitmask private constructor(
     private val bits: Int,
-    val length: Int
+    private val length: Int
 ): Iterable<Int> {
 
     operator fun get(index: Int) = ((bits shr index) and 1) == 1

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Bitmask.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Bitmask.kt
@@ -80,6 +80,62 @@ class Bitmask private constructor(
         }
     }
 
+    /**
+     * Returns a copy of this bitmask, but with the bit at [index] set.
+     */
+    fun withOnesAt(index: Int): Bitmask {
+        return Bitmask(bits = bits or (1 shl index), length = length)
+    }
+
+    /**
+     * Returns a copy of this bitmask, but with the bits at [index] set.
+     */
+    fun withOnesAt(vararg index: Int): Bitmask {
+        return Bitmask(bits = index.fold(bits) { result, i -> result or (1 shl i) }, length = length)
+    }
+
+    /**
+     * Counts the number of ones inside this bitmask.
+     *
+     * Example: `0b0110` returns `2`
+     */
+    fun count() = bits.countOneBits()
+
+    /**
+     * Returns the length of this bitmask.
+     *
+     * Example: `0b0110` returns `4`
+     */
+    fun size() = length
+
+    /**
+     * Returns the index of the lowest non-zero bit.
+     *
+     * Example: `0b0010` returns 1
+     */
+    fun lowestOneBitIndex() = bits.countTrailingZeroBits()
+
+    /**
+     * Returns the index of the lowest zero bit.
+     *
+     * Example: `0b0011` returns 2
+     */
+    fun lowestZeroBitIndex() = bits.inv().countTrailingZeroBits()
+
+    /**
+     * Returns the index of the highest non-zero bit.
+     *
+     * Example: `0b1010` returns 3
+     */
+    fun highestOneBitIndex() = Int.SIZE_BITS - bits.countLeadingZeroBits()
+
+    /**
+     * Returns the index of the highest zero bit.
+     *
+     * Example: `0b0010` returns 3
+     */
+    fun highestZeroBitIndex() = Int.SIZE_BITS - bits.inv().countLeadingZeroBits()
+
     override fun toString(): String {
         return "0b${bits.toBinaryString(length)}"
     }

--- a/tests/src/commonMain/kotlin/Main.kt
+++ b/tests/src/commonMain/kotlin/Main.kt
@@ -1,6 +1,6 @@
 import sparql.tests.compareIncrementalSelectOutput
 
 suspend fun main() {
-    compareIncrementalSelectOutput().run(count = 5).report()
+    compareIncrementalSelectOutput().run(count = 2).report()
 //    compareIncrementalBasicGraphPatternOutput().run().report()
 }

--- a/tests/src/commonMain/kotlin/Main.kt
+++ b/tests/src/commonMain/kotlin/Main.kt
@@ -1,6 +1,6 @@
-import sparql.tests.compareIncrementalBasicGraphPatternOutput
-
+import sparql.tests.compareIncrementalSelectOutput
 
 suspend fun main() {
-    compareIncrementalBasicGraphPatternOutput().run().report()
+    compareIncrementalSelectOutput().run(count = 5).report()
+//    compareIncrementalBasicGraphPatternOutput().run().report()
 }

--- a/tests/src/commonMain/kotlin/Main.kt
+++ b/tests/src/commonMain/kotlin/Main.kt
@@ -1,6 +1,6 @@
 import sparql.tests.compareIncrementalSelectOutput
 
 suspend fun main() {
-    compareIncrementalSelectOutput().run(count = 2).report()
+    compareIncrementalSelectOutput().run(count = 1).report()
 //    compareIncrementalBasicGraphPatternOutput().run().report()
 }

--- a/tests/src/commonMain/kotlin/sparql/Util.kt
+++ b/tests/src/commonMain/kotlin/sparql/Util.kt
@@ -4,4 +4,10 @@ import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 
 
-expect suspend fun executeExternalQuery(query: String, data: Store): List<Bindings>
+expect class ExternalQueryExecution(query: String, data: Store) {
+
+    suspend fun execute(): List<Bindings>
+
+    fun report(): String
+
+}

--- a/tests/src/commonMain/kotlin/sparql/tests/IncrementalSelect.kt
+++ b/tests/src/commonMain/kotlin/sparql/tests/IncrementalSelect.kt
@@ -1,0 +1,50 @@
+package sparql.tests
+
+import dev.tesserakt.rdf.dsl.RdfContext.Companion.buildStore
+import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
+import dev.tesserakt.rdf.types.Store
+import test.suite.testEnv
+import kotlin.random.Random
+import kotlin.time.measureTime
+
+/**
+ * Generates a random graph with a series of relationships and creates a test with a matching query using that graph.
+ * [depth] denotes the number of relations that make up a single "full" query (# of triple patterns with
+ *  fixed predicates); setting this value to less than 3 would result in no cache being used at evaluation
+ *  time (typically unwanted). The total amount of generated triples is [size] * [depth]
+ */
+fun compareIncrementalSelectOutput(size: Int = 200, depth: Int = 5) = testEnv {
+    val store: Store
+    val predicates = (0 ..< depth).map { "http://example.org/p_$it".asNamedTerm() }
+    val prepTime = measureTime {
+        store = buildStore {
+            val subjects = (0 .. depth).map { d -> (0..< 3 * size).map { local("s_${d}_$it") } }
+            repeat(size) {
+                // whether to generate a guaranteed full set
+                val isValid = Random.nextBoolean()
+                if (isValid) {
+                    var subject = subjects[0].random()
+                    repeat(depth) {
+                        val next = subjects[it + 1].random()
+                        subject has predicates[it] being next
+                        subject = next
+                    }
+                } else {
+                    // not keeping track of the individual subjects being linked
+                    repeat(depth) {
+                        subjects[it].random() has predicates[it] being subjects[it + 1].random()
+                    }
+                }
+            }
+        }
+    }
+    println("Random data store built: generated ${store.size} triples ($prepTime)!")
+    val query = buildString {
+        appendLine("SELECT * {")
+        repeat(depth) {
+            appendLine("\t?s${it} <${predicates[it]}> ?s${it + 1} .")
+        }
+        append("}")
+    }
+    using(store) test query
+}

--- a/tests/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
+++ b/tests/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
@@ -58,7 +58,7 @@ data class OutputComparisonTest(
 
         override fun exceptionOrNull(): Throwable? {
             return if (isNotEmpty()) {
-                AssertionError("Received results do not match expectations!\n$this\n * The following ${leftOver.size} binding(s) are superfluous:\n\t$leftOver\n * The following ${missing.size} binding(s) are missing:\n\t$missing\n")
+                AssertionError("Received results do not match expectations!\n$this\n * The following ${leftOver.size} binding(s) are superfluous:\n\t${leftOver.toTruncatedString(500)}\n * The following ${missing.size} binding(s) are missing:\n\t${missing.toTruncatedString(500)}\n")
             } else null
         }
 

--- a/tests/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
+++ b/tests/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
@@ -3,10 +3,13 @@ package sparql.types
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Compiler.Default.asSPARQLSelectQuery
 import dev.tesserakt.sparql.runtime.common.types.Bindings
+import dev.tesserakt.sparql.runtime.common.util.Debug
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery.Companion.query
-import sparql.executeExternalQuery
+import sparql.ExternalQueryExecution
 import test.suite.Test
 import test.suite.runTest
+import kotlin.time.Duration
+import kotlin.time.measureTime
 
 data class OutputComparisonTest(
     val query: String,
@@ -14,9 +17,23 @@ data class OutputComparisonTest(
 ) : Test {
 
     override suspend fun test() = runTest {
-        val actual = store.query(query.asSPARQLSelectQuery())
-        val expected = executeExternalQuery(query = query, data = store)
-        Result.from(received = actual, expected = expected)
+        val actual: List<Bindings>
+        Debug.reset()
+        val elapsedTime = measureTime {
+            actual = store.query(query.asSPARQLSelectQuery())
+        }
+        val external = ExternalQueryExecution(query, store)
+        val expected: List<Bindings>
+        val referenceTime = measureTime {
+            expected = external.execute()
+        }
+        Result.from(
+            received = actual,
+            expected = expected,
+            elapsedTime = elapsedTime,
+            referenceTime = referenceTime,
+            debugInformation = "${Debug.report()}${external.report()}"
+        )
     }
 
     override fun toString(): String =
@@ -28,7 +45,10 @@ data class OutputComparisonTest(
         val received: List<Bindings>,
         val expected: List<Bindings>,
         val leftOver: List<Bindings>,
-        val missing: List<Bindings>
+        val missing: List<Bindings>,
+        val elapsedTime: Duration,
+        val referenceTime: Duration,
+        val debugInformation: String
     ) : Test.Result {
 
         fun isNotEmpty() = leftOver.isNotEmpty() || missing.isNotEmpty()
@@ -42,14 +62,24 @@ data class OutputComparisonTest(
         }
 
         override fun toString(): String {
-            return " * Got ${received.size} binding(s):\n\t$received\n * Expected ${expected.size} binding(s):\n\t$expected"
+            return " * Got ${received.size} binding(s) ($elapsedTime):\n\t$received\n * Expected ${expected.size} binding(s) ($referenceTime):\n\t$expected\n * $debugInformation"
         }
 
         companion object {
 
-            fun from(received: List<Bindings>, expected: List<Bindings>): Result {
-                return compare(received, expected)
-            }
+            fun from(
+                received: List<Bindings>,
+                expected: List<Bindings>,
+                elapsedTime: Duration,
+                referenceTime: Duration,
+                debugInformation: String
+            ): Result = compare(
+                received = received,
+                expected = expected,
+                elapsedTime = elapsedTime,
+                referenceTime = referenceTime,
+                debugInformation = debugInformation
+            )
         }
 
     }
@@ -59,7 +89,13 @@ data class OutputComparisonTest(
 /**
  * Returns the diff of the two series of bindings. Ideally, the returned list is empty
  */
-private fun compare(received: List<Bindings>, expected: List<Bindings>): OutputComparisonTest.Result {
+private fun compare(
+    received: List<Bindings>,
+    expected: List<Bindings>,
+    elapsedTime: Duration,
+    referenceTime: Duration,
+    debugInformation: String
+): OutputComparisonTest.Result {
     val leftOver = received.toMutableList()
     val missing = mutableListOf<Bindings>()
     expected.forEach { bindings ->
@@ -67,7 +103,15 @@ private fun compare(received: List<Bindings>, expected: List<Bindings>): OutputC
             missing.add(bindings)
         }
     }
-    return OutputComparisonTest.Result(received = received, expected = expected, leftOver = leftOver, missing = missing)
+    return OutputComparisonTest.Result(
+        received = received,
+        expected = expected,
+        leftOver = leftOver,
+        missing = missing,
+        elapsedTime = elapsedTime,
+        referenceTime = referenceTime,
+        debugInformation = debugInformation
+    )
 }
 
 private inline fun <T> MutableList<T>.removeFirst(predicate: (T) -> Boolean): Boolean {

--- a/tests/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
+++ b/tests/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
@@ -5,6 +5,7 @@ import dev.tesserakt.sparql.Compiler.Default.asSPARQLSelectQuery
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 import dev.tesserakt.sparql.runtime.common.util.Debug
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery.Companion.query
+import dev.tesserakt.util.toTruncatedString
 import sparql.ExternalQueryExecution
 import test.suite.Test
 import test.suite.runTest
@@ -62,7 +63,7 @@ data class OutputComparisonTest(
         }
 
         override fun toString(): String {
-            return " * Got ${received.size} binding(s) ($elapsedTime):\n\t$received\n * Expected ${expected.size} binding(s) ($referenceTime):\n\t$expected\n * $debugInformation"
+            return " * Got ${received.size} binding(s) ($elapsedTime):\n\t${received.toTruncatedString(500)}\n * Expected ${expected.size} binding(s) ($referenceTime):\n\t${expected.toTruncatedString(500)}\n * $debugInformation"
         }
 
         companion object {

--- a/tests/src/commonMain/kotlin/test/suite/TestEnvironment.kt
+++ b/tests/src/commonMain/kotlin/test/suite/TestEnvironment.kt
@@ -49,6 +49,8 @@ class TestEnvironment {
 
     }
 
-    suspend fun run() = Results(results = tests.map { it to it.test() })
+    suspend fun run(count: Int = 1) = Results(
+        results = (0..<count).flatMap { tests.map { it to it.test() } }
+    )
 
 }

--- a/tests/src/jsMain/kotlin/comunica/Util.kt
+++ b/tests/src/jsMain/kotlin/comunica/Util.kt
@@ -1,5 +1,6 @@
 package comunica
 
+import dev.tesserakt.interop.rdfjs.n3.N3Store
 import dev.tesserakt.interop.rdfjs.n3.N3Term
 import dev.tesserakt.interop.rdfjs.toN3Store
 import dev.tesserakt.interop.rdfjs.toTerm
@@ -16,9 +17,12 @@ private fun ComunicaBinding.toBindings(): Bindings = js("Array")
     .associate { (name, term) -> name.value as String to term.unsafeCast<N3Term>().toTerm() }
 
 suspend fun Store.comunicaSelectQuery(query: String): List<Bindings> {
-    val n3store = toN3Store()
+    return toN3Store().comunicaSelectQuery(query)
+}
+
+suspend fun N3Store.comunicaSelectQuery(query: String): List<Bindings> {
     val opts: dynamic = Any()
-    opts.sources = arrayOf(n3store)
+    opts.sources = arrayOf(this)
     return engine
         .query(query, opts)
         .await()

--- a/tests/src/jsMain/kotlin/sparql/Util.kt
+++ b/tests/src/jsMain/kotlin/sparql/Util.kt
@@ -1,10 +1,29 @@
 package sparql
 
 import comunica.comunicaSelectQuery
+import dev.tesserakt.interop.rdfjs.n3.N3Store
+import dev.tesserakt.interop.rdfjs.toN3Store
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.runtime.common.types.Bindings
+import kotlin.time.measureTime
 
 
-actual suspend fun executeExternalQuery(query: String, data: Store): List<Bindings> {
-    return data.comunicaSelectQuery(query)
+actual class ExternalQueryExecution actual constructor(
+    private val query: String,
+    data: Store
+) {
+
+    private val store: N3Store
+    private val duration = measureTime {
+        store = data.toN3Store()
+    }
+
+    actual suspend fun execute(): List<Bindings> {
+        return store.comunicaSelectQuery(query)
+    }
+
+    actual fun report(): String {
+        return " * Comunica query execution\n\tPreparation took $duration"
+    }
+
 }

--- a/tests/src/jvmMain/kotlin/sparql/Util.kt
+++ b/tests/src/jvmMain/kotlin/sparql/Util.kt
@@ -5,22 +5,39 @@ import dev.tesserakt.interop.jena.toTerm
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.runtime.common.types.Bindings
+import org.apache.jena.query.Dataset
 import org.apache.jena.query.QueryExecutionFactory
+import kotlin.time.measureTime
 
 
-actual suspend fun executeExternalQuery(query: String, data: Store): List<Bindings> {
-    val store = data.toJenaDataset()
-    val results = mutableListOf<Bindings>()
-    QueryExecutionFactory.create(query, store).use { execution ->
-        val solutions = execution.execSelect()
-        while (solutions.hasNext()) {
-            val current = mutableMapOf<String, Quad.Term>()
-            val solution = solutions.nextSolution()
-            solution.varNames().forEach { name ->
-                solution[name]?.asNode()?.toTerm()?.let { current[name] = it }
-            }
-            results.add(current)
-        }
+actual class ExternalQueryExecution actual constructor(
+    private val query: String,
+    data: Store
+) {
+
+    private val store: Dataset
+    private val duration = measureTime {
+        store = data.toJenaDataset()
     }
-    return results
+
+    actual suspend fun execute(): List<Bindings> {
+        val results = mutableListOf<Bindings>()
+        QueryExecutionFactory.create(query, store).use { execution ->
+            val solutions = execution.execSelect()
+            while (solutions.hasNext()) {
+                val current = mutableMapOf<String, Quad.Term>()
+                val solution = solutions.nextSolution()
+                solution.varNames().forEach { name ->
+                    solution[name]?.asNode()?.toTerm()?.let { current[name] = it }
+                }
+                results.add(current)
+            }
+        }
+        return results
+    }
+
+    actual fun report(): String {
+        return " * Jena query execution\n\tPreparation took $duration"
+    }
+
 }


### PR DESCRIPTION
Added join tree type, with a left deep implementation (among other, unused POC variants), allowing for significant performance improvements during query body (pattern) and union (subqueries and other segments, performance & functionality untested) evaluation.
Also added a new data structure representing an array of mappings indexed on values, allowing for hash joining instead of nested loop joining, further improving performance during query evaluation. The new structure is used in the "array backed patterns" and new left deep join tree implementation.

Expanded the output comparison test implementation, now generating random triple stores based on input parameters, and measuring performance (evaluation time) between own implementation and reference implementation (interop module), tracking the number of joins against individual patterns (doesn't seem very insightful currently), and the time spent on converting the input triple store to the reference store type.