### PR TITLE
Insertion refactor

### DIFF
--- a/benchmarking/src/commonMain/kotlin/Main.kt
+++ b/benchmarking/src/commonMain/kotlin/Main.kt
@@ -1,16 +1,19 @@
 
 import dev.tesserakt.util.printerrln
 import sparql.tests.compareIncrementalBasicGraphPatternOutput
-import sparql.tests.compareIncrementalSelectOutput
+import sparql.tests.compareIncrementalChainSelectOutput
+import sparql.tests.compareIncrementalStarSelectOutput
 
 suspend fun run(args: Array<String>) {
     when (args.size) {
         0 -> {
             println("Running built-in tests")
-            val one = compareIncrementalSelectOutput().run()
-            val two = compareIncrementalBasicGraphPatternOutput().run()
+            val one = compareIncrementalChainSelectOutput(seed = 1).run()
+            val two = compareIncrementalStarSelectOutput(seed = 1).run()
+            val three = compareIncrementalBasicGraphPatternOutput().run()
             one.report()
             two.report()
+            three.report()
         }
         2 -> {
             val (dataset, querypath) = args

--- a/benchmarking/src/commonMain/kotlin/Main.kt
+++ b/benchmarking/src/commonMain/kotlin/Main.kt
@@ -1,3 +1,4 @@
+
 import dev.tesserakt.util.printerrln
 import sparql.tests.compareIncrementalBasicGraphPatternOutput
 import sparql.tests.compareIncrementalSelectOutput

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Incremental.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Incremental.kt
@@ -213,6 +213,24 @@ fun compareIncrementalBasicGraphPatternOutput() = testEnv {
         }
     """
 
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            <http://example.org/a> <http://example.org/p>+ <http://example.org/b>
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            ?a <http://example.org/p>+ <http://example.org/b>
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            ?a <http://example.org/p>+ ?b
+        }
+    """
+
     val unions = buildStore("http://www.example.org/") {
         val a = local("a")
         val b = local("b")
@@ -275,6 +293,13 @@ fun compareIncrementalBasicGraphPatternOutput() = testEnv {
         PREFIX : <http://www.example.org/>
         SELECT ?v WHERE {
             ?a :p* ?v
+        }
+    """
+
+    using (literals) test """
+        PREFIX : <http://www.example.org/>
+        SELECT ?v WHERE {
+            ?a :p+ ?v
         }
     """
 
@@ -346,6 +371,14 @@ fun compareIncrementalBasicGraphPatternOutput() = testEnv {
 
     using(person2) test """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT ?node {
+            ?node rdf:rest+ ?blank .
+            ?blank rdf:rest rdf:nil .
+        }
+    """
+
+    using(person2) test """
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX ex: <https://www.example.org/>
         SELECT ?person ?note {
             ?person a ex:person ; ex:notes/rdf:rest*/rdf:first ?note
@@ -354,8 +387,23 @@ fun compareIncrementalBasicGraphPatternOutput() = testEnv {
 
     using(person2) test """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX ex: <https://www.example.org/>
+        SELECT ?person ?note {
+            ?person a ex:person ; ex:notes/rdf:rest+/rdf:first ?note
+        }
+    """
+
+    using(person2) test """
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         SELECT * {
             ?s (rdf:|!rdf:)* ?o
+        }
+    """
+
+    using(person2) test """
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        SELECT * {
+            ?s (rdf:|!rdf:)+ ?o
         }
     """
 
@@ -466,4 +514,49 @@ fun compareIncrementalBasicGraphPatternOutput() = testEnv {
 //        GROUP BY ?org
 //        HAVING (SUM(?lprice) > 10)
 //    """
+
+    val aux1 = buildStore("http://example.org/") {
+        val s0 = local("s0")
+        val s1 = local("s1")
+        val p1 = local("p1")
+        val p2 = local("p2")
+        val o = local("o")
+        val x = local("x")
+
+        s0 has p2 being x
+        x has p1 being o
+        s1 has p1 being o
+    }
+
+    using(aux1) test """
+        PREFIX : <http://example.org/>
+        SELECT * WHERE {
+            ?a :p1 ?b .
+            ?d :p2 ?c .
+            ?c :p1|:p2 :o
+        }
+    """
+
+    val aux2 = buildStore("http://example.org/") {
+        val s0 = local("s0")
+        val s1 = local("s1")
+        val p1 = local("p1")
+        val p2 = local("p2")
+        val o = local("o")
+        val x = local("x")
+
+        s0 has p2 being x
+        s1 has p2 being o
+        x has p1 being o
+    }
+
+    using(aux2) test """
+        PREFIX : <http://example.org/>
+        SELECT * WHERE {
+            ?a :p1 ?b .
+            ?d :p2 ?c .
+            ?c :p1|:p2 :o
+        }
+    """
+
 }

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Incremental.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Incremental.kt
@@ -223,4 +223,27 @@ fun compareIncrementalBasicGraphPatternOutput() = testEnv {
         }
     """
 
+    val extra = buildStore {
+        val a = "http://www.example.org/a".asNamedTerm()
+        val b = "http://www.example.org/b".asNamedTerm()
+        val c = "http://www.example.org/c".asNamedTerm()
+        val d = "http://www.example.org/d".asNamedTerm()
+        val p = "http://www.example.org/p".asNamedTerm()
+
+        a has p being 11
+        a has p being b
+        b has p being 12
+        b has p being c
+        c has p being 13
+        c has p being d
+        d has p being 14
+    }
+
+    using (extra) test """
+        PREFIX : <http://www.example.org/>
+        SELECT ?v WHERE {
+            ?a :p* ?v
+        }
+    """
+
 }

--- a/benchmarking/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
@@ -25,7 +25,11 @@ data class OutputComparisonTest(
         val external = ExternalQueryExecution(query, store)
         val expected: List<Bindings>
         val referenceTime = measureTime {
-            expected = external.execute()
+            try {
+                expected = external.execute()
+            } catch (t: Throwable) {
+                return Test.Result.Failure(RuntimeException("Failed to use external implementation reference: ${t.message}", t))
+            }
         }
         Result.from(
             received = actual,

--- a/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
+++ b/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
@@ -46,6 +46,7 @@ fun N3NamedNode.toTerm() = Quad.NamedTerm(value = value)
 private object N3XSD {
     val string = XSD.string.toN3Term()
     val int = XSD.int.toN3Term()
+    val integer = XSD.integer.toN3Term()
     val long = XSD.long.toN3Term()
     val float = XSD.float.toN3Term()
     val double = XSD.double.toN3Term()
@@ -54,12 +55,12 @@ private object N3XSD {
 
 fun N3Literal.toTerm() = when (datatype) {
     N3XSD.string -> Quad.Literal(value, type = XSD.string)
-    N3XSD.int -> Quad.Literal(value.toInt(), type = XSD.int)
+    N3XSD.int, N3XSD.integer -> Quad.Literal(value.toInt(), type = XSD.int)
     N3XSD.long -> Quad.Literal(value.toLong(), type = XSD.long)
     N3XSD.float -> Quad.Literal(value.toFloat(), type = XSD.float)
     N3XSD.double -> Quad.Literal(value.toDouble(), type = XSD.double)
     N3XSD.boolean -> Quad.Literal(value.toBoolean(), type = XSD.boolean)
-    else -> throw IllegalArgumentException("Unknown datatype `$datatype`")
+    else -> throw IllegalArgumentException("Unknown datatype `${datatype.value}`")
 }
 
 fun N3BlankNode.toTerm() = Quad.BlankTerm(id = value.takeLastWhile { it.isDigit() }.toInt())

--- a/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/ontology/XSD.kt
+++ b/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/ontology/XSD.kt
@@ -12,6 +12,7 @@ object XSD: Ontology {
     val string = "${base_uri}string".asNamedTerm()
     val boolean = "${base_uri}boolean".asNamedTerm()
     val int = "${base_uri}int".asNamedTerm()
+    val integer = "${base_uri}integer".asNamedTerm()
     val long = "${base_uri}long".asNamedTerm()
     val float = "${base_uri}float".asNamedTerm()
     val double = "${base_uri}double".asNamedTerm()

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/types/Pattern.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/types/Pattern.kt
@@ -60,7 +60,12 @@ data class Pattern(
 
     @JvmInline
     value class Alts(val allowed: List<Predicate>) : Predicate {
-        override fun toString() = allowed.joinToString(" | ")
+        override fun toString() = allowed.joinToString(
+            separator = " | ",
+            prefix = "(",
+            postfix = ")",
+            transform = { "($it)" }
+        )
     }
 
     @JvmInline

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/types/Pattern.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/types/Pattern.kt
@@ -55,7 +55,7 @@ data class Pattern(
     // FIXME: inverse can either be the inverse of a term (this case) AS WELL AS the inverse of a path (^iri)
     @JvmInline
     value class Negated(val term: Quad.Term) : UnboundPredicate {
-        override fun toString() = "!$term"
+        override fun toString() = "!($term)"
     }
 
     @JvmInline
@@ -70,7 +70,12 @@ data class Pattern(
 
     @JvmInline
     value class UnboundAlts(val allowed: List<UnboundPredicate>) : UnboundPredicate {
-        override fun toString() = allowed.joinToString(" | ")
+        override fun toString() = allowed.joinToString(
+            separator = " | ",
+            prefix = "(",
+            postfix = ")",
+            transform = { "($it)" }
+        )
     }
 
     /*
@@ -79,7 +84,12 @@ data class Pattern(
     */
     @JvmInline
     value class Sequence(val chain: List<Predicate>) : Predicate {
-        override fun toString() = chain.joinToString(" / ")
+        override fun toString() = chain.joinToString(
+            separator = " / ",
+            prefix = "(",
+            postfix = ")",
+            transform = { "($it)" }
+        )
     }
 
     /*
@@ -92,12 +102,12 @@ data class Pattern(
 
     @JvmInline
     value class ZeroOrMore(override val element: UnboundPredicate): RepeatingPredicate, UnboundPredicate {
-        override fun toString() = "$element*"
+        override fun toString() = "($element)*"
     }
 
     @JvmInline
     value class OneOrMore(override val element: UnboundPredicate): RepeatingPredicate, UnboundPredicate {
-        override fun toString() = "$element+"
+        override fun toString() = "($element)+"
     }
 
     override fun toString() = "$s $p $o"

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/core/Mapping.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/core/Mapping.kt
@@ -17,3 +17,5 @@ fun mappingOf(vararg pairs: Pair<String?, Quad.Term>): Mapping = HashMap<String,
             }
         }
     }
+
+fun emptyMapping(): Mapping = emptyMap()

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
@@ -1,0 +1,17 @@
+package dev.tesserakt.sparql.runtime.incremental.collection
+
+import dev.tesserakt.sparql.runtime.core.Mapping
+
+interface JoinCollection {
+
+    val mappings: List<Mapping>
+
+    fun join(other: JoinCollection): List<Mapping>
+
+    fun join(mappings: List<Mapping>): List<Mapping>
+
+    fun add(mapping: Mapping)
+
+    fun addAll(mappings: Collection<Mapping>)
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
@@ -31,6 +31,8 @@ internal value class NestedJoinArray(
         this.mappings.addAll(mappings)
     }
 
+    override fun toString() = "NestedJoinArray (cardinality ${mappings.size})"
+
 }
 
 @Suppress("NOTHING_TO_INLINE")

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
@@ -1,0 +1,44 @@
+package dev.tesserakt.sparql.runtime.incremental.collection
+
+import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.util.compatibleWith
+import kotlin.jvm.JvmInline
+
+@JvmInline
+internal value class NestedJoinArray(
+    override val mappings: ArrayList<Mapping> = ArrayList()
+): JoinCollection {
+
+    constructor(mappings: Collection<Mapping>): this(ArrayList(mappings))
+
+    override fun join(other: JoinCollection): List<Mapping> {
+        return if (other is HashJoinArray) {
+            other.join(mappings)
+        } else {
+            doNestedJoin(a = mappings, b = other.mappings)
+        }
+    }
+
+    override fun join(mappings: List<Mapping>): List<Mapping> {
+        return doNestedJoin(a = this.mappings, b = mappings)
+    }
+
+    override fun add(mapping: Mapping) {
+        this.mappings.add(mapping)
+    }
+
+    override fun addAll(mappings: Collection<Mapping>) {
+        this.mappings.addAll(mappings)
+    }
+
+}
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun doNestedJoin(a: List<Mapping>, b: List<Mapping>) = buildList(a.size + b.size) {
+    a.forEach { left ->
+        b.forEach { right ->
+            if (left.compatibleWith(right)) add(left + right)
+        }
+    }
+}
+

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/Util.kt
@@ -1,0 +1,11 @@
+package dev.tesserakt.sparql.runtime.incremental.collection
+
+internal fun mutableJoinCollection(bindings: Collection<String>) = when {
+    bindings.isNotEmpty() -> HashJoinArray(bindings = bindings.toSet())
+    else -> NestedJoinArray()
+}
+
+internal fun mutableJoinCollection(vararg bindings: String?): JoinCollection {
+    val set = setOfNotNull(*bindings)
+    return mutableJoinCollection(set)
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/compat/PatternCompatLayer.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/compat/PatternCompatLayer.kt
@@ -67,16 +67,13 @@ class PatternCompatLayer(
     ) {
         when (pred) {
             is PatternAST.Alts -> {
-                val segments = pred.allowed.map { alt ->
-                    val builder = StatementsBuilder()
-                    builder.insert(
-                        subj = subj,
-                        pred = alt,
-                        obj = obj
+                insert(
+                    Pattern(
+                        s = subj.toPatternSubject(),
+                        Pattern.Alts(pred.allowed.map { it.toPatternPredicate() }),
+                        o = obj.toPatternObject(this)
                     )
-                    builder.build()
-                }
-                insert(segments)
+                )
             }
 
             is PatternAST.Chain -> {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
@@ -64,7 +64,7 @@ sealed class IncrementalQuery<ResultType, Q: Query>(
             }
             while (iterator.hasNext()) {
                 val triple = iterator.next()
-                val results = state.process(triple)
+                val results = state.insert(triple)
                 return when (results.size) {
                     // continuing looping
                     0 -> continue

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/HashJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/HashJoinArray.kt
@@ -27,6 +27,7 @@ class HashJoinArray(bindings: Collection<String>) {
         check(bindings.isNotEmpty()) { "Invalid use of hash join array! No bindings are used!" }
     }
 
+    val mappings: List<Mapping> get() = backing
     /**
      * Denotes the number of matches it contains, useful for quick cardinality calculations (e.g., joining this state
      *  on an empty solution results in [size] results, or a size of 0 guarantees no results will get generated)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -17,9 +17,20 @@ internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
     val bindings: Set<String> = ast.getAllNamedBindings().map { it.name }.toSet()
 
     fun insert(quad: Quad): List<Mapping> {
-        val first = patterns.insert(quad)
-        val second = unions.insert(quad)
+        val total = delta(quad)
+        process(quad)
+        return total
+    }
+
+    fun delta(quad: Quad): List<Mapping> {
+        val first = patterns.delta(quad)
+        val second = unions.delta(quad)
         return patterns.join(second) + unions.join(first)
+    }
+
+    fun process(quad: Quad) {
+        patterns.process(quad)
+        unions.process(quad)
     }
 
     fun join(mappings: List<Mapping>): List<Mapping> {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -7,8 +7,8 @@ import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
 
 internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
 
-    private val patterns = JoinTree.None(ast.patterns)
-    private val unions = JoinTree.None(ast.unions)
+    private val patterns = JoinTree(ast.patterns)
+    private val unions = JoinTree(ast.unions)
 
     /**
      * A collection of all bindings found inside this query body; it is not guaranteed that all solutions generated

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -2,123 +2,33 @@ package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.core.Mapping
-import dev.tesserakt.sparql.runtime.incremental.state.IncrementalTriplePatternState.Companion.createIncrementalPatternState
 import dev.tesserakt.sparql.runtime.incremental.types.Query
-import dev.tesserakt.sparql.runtime.util.Bitmask
+import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
 
 internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
 
-    private val bodyTree = JoinTree.LeftDeep()
-    private val unionTree = JoinTree.LeftDeep()
-    private val patterns = ast.patterns
-        // sorting the patterns based on the used join tree implementation
-        .let { bodyTree.sorted(it) }
-        // and converting them into separate states, retaining that order
-        .map { it.createIncrementalPatternState() }
-    private val unions = ast.unions.map { union -> IncrementalUnionState(union) }
+    private val patterns = JoinTree.None(ast.patterns)
+    private val unions = JoinTree.None(ast.unions)
 
-    fun delta(quad: Quad): List<Mapping> {
-        val base = with (bodyTree) {
-            patterns
-                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = patterns.size) to pattern.delta(quad) }
-                .expandResultSet()
-                .growUsingCache()
-                .flatMap { (mask, mappings) ->
-                    // as we only need to iterate over the patterns not yet managed, we need to inverse the bitmask
-                    //  before iterating over it
-                    mask.inv().fold(mappings) { results, i -> if (results.isEmpty()) return@flatMap emptyList() else patterns[i].join(results) }
-                }
-        }
-        val first = unions.fold(initial = base) { results, u -> u.join(results) }
-        return first + with (unionTree) {
-            unions
-                .mapIndexed { i, union -> Bitmask.onesAt(i, length = unions.size) to union.delta(quad) }
-                .expandResultSet()
-                .growUsingCache()
-                .flatMap { (mask, mappings) ->
-                    // as we only need to iterate over the unions not yet managed, we need to inverse the bitmask
-                    //  before iterating over it
-                    mask.inv().fold(mappings) { results, i -> unions[i].join(results) }
-                }
-                .let { patterns.fold(it) { results, p -> p.join(results) } }
-        }
+    /**
+     * A collection of all bindings found inside this query body; it is not guaranteed that all solutions generated
+     *  through [insert]ion have a value for all of these bindings, as this depends on the query itself
+     */
+    val bindings: Set<String> = ast.getAllNamedBindings().map { it.name }.toSet()
+
+    fun insert(quad: Quad): List<Mapping> {
+        val first = patterns.insert(quad)
+        val second = unions.insert(quad)
+        return patterns.join(second) + unions.join(first)
     }
 
-    fun process(quad: Quad): List<Mapping> {
-        val results = delta(quad)
-        insert(quad)
-        return results
-    }
-
-    fun insert(quad: Quad) {
-        // first updating the cache before individual child states are altered so the delta calculations are correct
-        updateCache(quad)
-        // now the child states can also insert the quad
-        patterns.forEach { it.insert(quad) }
-        unions.forEach { it.insert(quad) }
-    }
-
-    fun join(mappings: List<Mapping>): List<Mapping> = unions
-        .fold(initial = patterns.fold(mappings) { results, p -> p.join(results) }) { results, u -> u.join(results) }
-
-    // TODO: overhaul this state's API so delta + insertion can be done in a single call, which can then also
-    //  reduce the # of "delta processing" required
-    // TODO: may also benefit from the same original cache use as noted by the original "delta" above
-    private fun updateCache(quad: Quad) {
-        // updating the cache pattern-wise
-        with (bodyTree) {
-            patterns
-                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = patterns.size) to pattern.delta(quad) }
-                .expandResultSet()
-                .growUsingCache()
-                .flatMap { (mask, mappings) ->
-                    // inserting the new item(s) first - this iteration can be the result from `expandResultSet` and
-                    //  satisfy multiple triple patterns already
-                    bodyTree.insert(mask, mappings)
-                    // as we only need to iterate over the patterns not yet managed, we need to inverse the bitmask
-                    //  before iterating over it
-                    var currentMask = mask
-                    mask.inv().fold(mappings) { results, i ->
-                        val result = patterns[i].join(results)
-                        if (result.isEmpty()) {
-                            return@flatMap emptyList()
-                        }
-                        currentMask = currentMask.withOnesAt(i)
-                        bodyTree.insert(currentMask, result)
-                        result
-                    }
-                }
-        }
-        // updating the plan union-wise
-        with (unionTree) {
-            unions
-                .mapIndexed { i, union -> Bitmask.onesAt(i, length = unions.size) to union.delta(quad) }
-                .expandResultSet()
-                .growUsingCache()
-                .flatMap { (mask, mappings) ->
-                    // inserting the new item(s) first - this iteration can be the result from `expandResultSet` and
-                    //   satisfy multiple unions already
-                    unionTree.insert(mask, mappings)
-                    // as we only need to iterate over the unions not yet managed, we need to inverse the bitmask
-                    //  before iterating over it
-                    var currentMask = mask
-                    mask.inv().fold(mappings) { results, i ->
-                        val result = unions[i].join(results)
-                        currentMask = currentMask.withOnesAt(i)
-                        unionTree.insert(currentMask, result)
-                        result
-                    }
-                }
-                .let { patterns.fold(it) { results, p -> p.join(results) } }
-        }
+    fun join(mappings: List<Mapping>): List<Mapping> {
+        return patterns.join(mappings)
     }
 
     fun debugInformation() = buildString {
-        appendLine("* Pattern states")
-        patterns.forEach { pattern ->
-            appendLine("\t$pattern")
-        }
-        appendLine(bodyTree.debugInfo())
+        appendLine("* Pattern state")
+        append(patterns.debugInformation())
     }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -4,76 +4,167 @@ package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.sparql.runtime.common.types.Pattern
 import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.core.emptyMapping
 import dev.tesserakt.sparql.runtime.core.mappingOf
-import dev.tesserakt.sparql.runtime.core.pattern.bindingName
+import dev.tesserakt.sparql.runtime.incremental.collection.mutableJoinCollection
 import dev.tesserakt.sparql.runtime.incremental.types.SegmentsList
 
-internal sealed class IncrementalPathState(
-    protected val start: Pattern.Subject,
-    protected val end: Pattern.Object
-) {
+internal sealed class IncrementalPathState {
 
-    protected val segments = SegmentsList()
-    private val bs = start.bindingName
-    private val bo = end.bindingName
+    class ZeroOrMoreBinding(
+        val start: Pattern.Binding,
+        val end: Pattern.Binding
+    ) : IncrementalPathState() {
 
-    protected fun SegmentsList.Segment.toMapping() = mappingOf(bs to start, bo to end)
+        private val segments = SegmentsList()
+        private val arr = mutableJoinCollection(start.name, end.name)
 
-    class ZeroOrMore(
-        start: Pattern.Subject,
-        end: Pattern.Object
-    ) : IncrementalPathState(start = start, end = end) {
+        override val cardinality: Int get() = arr.mappings.size
 
         override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            val result = segments.newPathsOnAdding(segment).toMutableList()
+            val delta = segments.newPathsOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
             // only accepting all paths that adhere to the constraints above: if one represents a binding, it gets
             //  added to the resulting mappings; else, it gets filtered out if it doesn't match in value
-            // FIXME can be done directly in segment list for efficiency
-            if (start is Pattern.Exact) {
-                result.removeAll { it.start != start.term }
-            }
-            if (end is Pattern.Exact) {
-                result.removeAll { it.end != end.term }
-            }
             if (segment.start !in segments.nodes) {
-                result += SegmentsList.Segment(start = segment.start, end = segment.start)
+                delta.add(mappingOf(start.name to segment.start, end.name to segment.start))
             }
             if (segment.start != segment.end && segment.end !in segments.nodes) {
-                result += SegmentsList.Segment(start = segment.end, end = segment.end)
+                delta.add(mappingOf(start.name to segment.end, end.name to segment.end))
             }
-            val delta = result.map { it.toMapping() }.distinct()
             segments.insert(segment)
+            arr.addAll(delta)
             return delta
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
         }
 
     }
 
-    class OneOrMore(
-        start: Pattern.Subject,
-        end: Pattern.Object
-    ) : IncrementalPathState(start = start, end = end) {
+    class ZeroOrMoreBindingExact(
+        val start: Pattern.Binding,
+        val end: Pattern.Exact
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList()
+        private val arr = mutableJoinCollection(start.name)
+
+        override val cardinality: Int get() = arr.mappings.size
 
         override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            val result = segments.newPathsOnAdding(segment).toMutableList()
-            // only accepting all paths that adhere to the constraints above: if one represents a binding, it gets
-            //  added to the resulting mappings; else, it gets filtered out if it doesn't match in value
-            // FIXME can be done directly in segment list for efficiency
-            if (start is Pattern.Exact) {
-                result.removeAll { it.start != start.term }
-            }
-            if (end is Pattern.Exact) {
-                result.removeAll { it.end != end.term }
-            }
-            val delta = result.map { it.toMapping() }.distinct()
+            val delta = segments.newReachableStartNodesOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(start.name to it) }
             segments.insert(segment)
+            arr.addAll(delta)
             return delta
         }
 
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
     }
+
+    class ZeroOrMoreExactBinding(
+        val start: Pattern.Exact,
+        val end: Pattern.Binding
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList()
+        private val arr = mutableJoinCollection(end.name)
+
+        override val cardinality: Int get() = arr.mappings.size
+
+        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
+            val delta = segments.newReachableEndNodesOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(end.name to it) }
+            segments.insert(segment)
+            arr.addAll(delta)
+            return delta
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
+    }
+
+    class ZeroOrMoreExact(
+        val start: Pattern.Exact,
+        val end: Pattern.Exact
+    ) : IncrementalPathState() {
+
+        private var satisfied = false
+
+        override val cardinality: Int get() = if (satisfied) 1 else 0
+
+        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
+            return if (!satisfied) {
+                satisfied = true
+                listOf(emptyMapping())
+            } else {
+                emptyList()
+            }
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return if (satisfied) mappings else emptyList()
+        }
+
+    }
+
+//    class OneOrMore(
+//        start: Pattern.Subject,
+//        end: Pattern.Object
+//    ) : IncrementalPathState(start = start, end = end) {
+//
+//        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
+//            val result = segments.newPathsOnAdding(segment).toMutableList()
+//            // only accepting all paths that adhere to the constraints above: if one represents a binding, it gets
+//            //  added to the resulting mappings; else, it gets filtered out if it doesn't match in value
+//            // FIXME can be done directly in segment list for efficiency
+//            if (start is Pattern.Exact) {
+//                result.removeAll { it.start != start.term }
+//            }
+//            if (end is Pattern.Exact) {
+//                result.removeAll { it.end != end.term }
+//            }
+//            val delta = result.map { it.toMapping() }.distinct()
+//            segments.insert(segment)
+//            return delta
+//        }
+//
+//    }
+
+    abstract val cardinality: Int
 
     abstract fun insert(segment: SegmentsList.Segment): List<Mapping>
 
-    final override fun toString() = "${this@IncrementalPathState::class.simpleName} - $segments"
+    abstract fun join(mappings: List<Mapping>): List<Mapping>
+
+    companion object {
+
+        fun zeroOrMore(
+            start: Pattern.Subject,
+            end: Pattern.Object
+        ) = when {
+            start is Pattern.Exact && end is Pattern.Exact -> ZeroOrMoreExact(start, end)
+            start is Pattern.Binding && end is Pattern.Binding -> ZeroOrMoreBinding(start, end)
+            start is Pattern.Exact && end is Pattern.Binding -> ZeroOrMoreExactBinding(start, end)
+            start is Pattern.Binding && end is Pattern.Exact -> ZeroOrMoreBindingExact(start, end)
+            else -> throw IllegalStateException("Unknown subject / pattern combination for `ZeroOrMore` predicate construct: $start -> $end")
+        }
+
+        fun oneOrMore(
+            start: Pattern.Subject,
+            end: Pattern.Object
+        ): Nothing = when {
+            else -> throw IllegalStateException("Unknown subject / pattern combination for `OneOrMore` predicate construct: $start -> $end")
+        }
+
+    }
 
 }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -14,7 +14,7 @@ internal sealed class IncrementalPathState {
         val end: Pattern.Binding
     ) : IncrementalPathState() {
 
-        private val segments = SegmentsList()
+        private val segments = SegmentsList.ZeroLength()
         private val arr = mutableJoinCollection(start.name, end.name)
 
         override val cardinality: Int get() = arr.mappings.size
@@ -26,17 +26,8 @@ internal sealed class IncrementalPathState {
         }
 
         override fun delta(segment: SegmentsList.Segment): List<Mapping> {
-            val delta = segments.newPathsOnAdding(segment)
+            return segments.newPathsOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
-            // only accepting all paths that adhere to the constraints above: if one represents a binding, it gets
-            //  added to the resulting mappings; else, it gets filtered out if it doesn't match in value
-            if (segment.start !in segments.nodes) {
-                delta.add(mappingOf(start.name to segment.start, end.name to segment.start))
-            }
-            if (segment.start != segment.end && segment.end !in segments.nodes) {
-                delta.add(mappingOf(start.name to segment.end, end.name to segment.end))
-            }
-            return delta
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -52,7 +43,7 @@ internal sealed class IncrementalPathState {
         val end: Pattern.Exact
     ) : IncrementalPathState() {
 
-        private val segments = SegmentsList()
+        private val segments = SegmentsList.ZeroLength()
         private val arr = mutableJoinCollection(start.name)
 
         override val cardinality: Int get() = arr.mappings.size
@@ -79,7 +70,7 @@ internal sealed class IncrementalPathState {
         val end: Pattern.Binding
     ) : IncrementalPathState() {
 
-        private val segments = SegmentsList()
+        private val segments = SegmentsList.ZeroLength()
         private val arr = mutableJoinCollection(end.name)
 
         override val cardinality: Int get() = arr.mappings.size
@@ -130,101 +121,117 @@ internal sealed class IncrementalPathState {
 
     }
 
-//    class OneOrMoreBinding(
-//        val start: Pattern.Binding,
-//        val end: Pattern.Binding
-//    ) : IncrementalPathState() {
-//
-//        private val segments = SegmentsList()
-//        private val arr = mutableJoinCollection(start.name, end.name)
-//
-//        override val cardinality: Int get() = arr.mappings.size
-//
-//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
-//            val delta = segments.newPathsOnAdding(segment)
-//                .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
-//            segments.insert(segment)
-//            arr.addAll(delta)
-//            return delta
-//        }
-//
-//        override fun join(mappings: List<Mapping>): List<Mapping> {
-//            return arr.join(mappings)
-//        }
-//
-//    }
-//
-//    class OneOrMoreBindingExact(
-//        val start: Pattern.Binding,
-//        val end: Pattern.Exact
-//    ) : IncrementalPathState() {
-//
-//        private val segments = SegmentsList()
-//        private val arr = mutableJoinCollection(start.name)
-//
-//        override val cardinality: Int get() = arr.mappings.size
-//
-//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
-//            val delta = segments.newReachableStartNodesOnAdding(segment)
-//                .mapTo(ArrayList()) { mappingOf(start.name to it) }
-//            segments.insert(segment)
-//            arr.addAll(delta)
-//            return delta
-//        }
-//
-//        override fun join(mappings: List<Mapping>): List<Mapping> {
-//            return arr.join(mappings)
-//        }
-//
-//    }
-//
-//    class OneOrMoreExactBinding(
-//        val start: Pattern.Exact,
-//        val end: Pattern.Binding
-//    ) : IncrementalPathState() {
-//
-//        private val segments = SegmentsList()
-//        private val arr = mutableJoinCollection(end.name)
-//
-//        override val cardinality: Int get() = arr.mappings.size
-//
-//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
-//            val delta = segments.newReachableEndNodesOnAdding(segment)
-//                .mapTo(ArrayList()) { mappingOf(end.name to it) }
-//            segments.insert(segment)
-//            arr.addAll(delta)
-//            return delta
-//        }
-//
-//        override fun join(mappings: List<Mapping>): List<Mapping> {
-//            return arr.join(mappings)
-//        }
-//
-//    }
-//
-//    class OneOrMoreExact(
-//        val start: Pattern.Exact,
-//        val end: Pattern.Exact
-//    ) : IncrementalPathState() {
-//
-//        private var satisfied = false
-//
-//        override val cardinality: Int get() = if (satisfied) 1 else 0
-//
-//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
-//            return if (!satisfied) {
-//                satisfied = true
-//                listOf(emptyMapping())
-//            } else {
-//                emptyList()
-//            }
-//        }
-//
-//        override fun join(mappings: List<Mapping>): List<Mapping> {
-//            return if (satisfied) mappings else emptyList()
-//        }
-//
-//    }
+    class OneOrMoreBinding(
+        val start: Pattern.Binding,
+        val end: Pattern.Binding
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList.SingleLength()
+        private val arr = mutableJoinCollection(start.name, end.name)
+
+        override val cardinality: Int get() = arr.mappings.size
+
+        override fun process(segment: SegmentsList.Segment) {
+            val delta = delta(segment)
+            segments.insert(segment)
+            arr.addAll(delta)
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+            return segments.newPathsOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
+        override fun toString() = segments.toString()
+
+    }
+
+    class OneOrMoreBindingExact(
+        val start: Pattern.Binding,
+        val end: Pattern.Exact
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList.SingleLength()
+        private val arr = mutableJoinCollection(start.name)
+
+        override val cardinality: Int get() = arr.mappings.size
+
+        override fun process(segment: SegmentsList.Segment) {
+            val delta = delta(segment)
+            segments.insert(segment)
+            arr.addAll(delta)
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+            return segments.newReachableStartNodesOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(start.name to it) }
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
+    }
+
+    class OneOrMoreExactBinding(
+        val start: Pattern.Exact,
+        val end: Pattern.Binding
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList.SingleLength()
+        private val arr = mutableJoinCollection(end.name)
+
+        override val cardinality: Int get() = arr.mappings.size
+
+        override fun process(segment: SegmentsList.Segment) {
+            val delta = delta(segment)
+            segments.insert(segment)
+            arr.addAll(delta)
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+            return segments.newReachableEndNodesOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(end.name to it) }
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
+    }
+
+    class OneOrMoreExact(
+        val start: Pattern.Exact,
+        val end: Pattern.Exact
+    ) : IncrementalPathState() {
+
+        private var satisfied = false
+
+        override val cardinality: Int get() = if (satisfied) 1 else 0
+
+        override fun process(segment: SegmentsList.Segment) {
+            satisfied = true
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+            // it's expected that a call to `process` will happen soon after,
+            //  so not changing it here
+            return if (!satisfied) {
+                listOf(emptyMapping())
+            } else {
+                emptyList()
+            }
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return if (satisfied) mappings else emptyList()
+        }
+
+    }
 
     abstract val cardinality: Int
 
@@ -250,11 +257,11 @@ internal sealed class IncrementalPathState {
         fun oneOrMore(
             start: Pattern.Subject,
             end: Pattern.Object
-        ) : Nothing = when {
-//            start is Pattern.Exact && end is Pattern.Exact -> OneOrMoreExact(start, end)
-//            start is Pattern.Binding && end is Pattern.Binding -> OneOrMoreBinding(start, end)
-//            start is Pattern.Exact && end is Pattern.Binding -> OneOrMoreExactBinding(start, end)
-//            start is Pattern.Binding && end is Pattern.Exact -> OneOrMoreBindingExact(start, end)
+        ) = when {
+            start is Pattern.Exact && end is Pattern.Exact -> OneOrMoreExact(start, end)
+            start is Pattern.Binding && end is Pattern.Binding -> OneOrMoreBinding(start, end)
+            start is Pattern.Exact && end is Pattern.Binding -> OneOrMoreExactBinding(start, end)
+            start is Pattern.Binding && end is Pattern.Exact -> OneOrMoreBindingExact(start, end)
             else -> throw IllegalStateException("Unknown subject / pattern combination for `OneOrMore` predicate construct: $start -> $end")
         }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -20,6 +20,7 @@ internal sealed class IncrementalPathState {
         override val cardinality: Int get() = arr.mappings.size
 
         override fun process(segment: SegmentsList.Segment) {
+            // TODO(perf): this delta's the segments list twice, can be optimised
             val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)
@@ -49,6 +50,7 @@ internal sealed class IncrementalPathState {
         override val cardinality: Int get() = arr.mappings.size
 
         override fun process(segment: SegmentsList.Segment) {
+            // TODO(perf): this delta's the segments list twice, can be optimised
             val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)
@@ -76,6 +78,7 @@ internal sealed class IncrementalPathState {
         override val cardinality: Int get() = arr.mappings.size
 
         override fun process(segment: SegmentsList.Segment) {
+            // TODO(perf): this delta's the segments list twice, can be optimised
             val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)
@@ -132,6 +135,7 @@ internal sealed class IncrementalPathState {
         override val cardinality: Int get() = arr.mappings.size
 
         override fun process(segment: SegmentsList.Segment) {
+            // TODO(perf): this delta's the segments list twice, can be optimised
             val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)
@@ -161,6 +165,7 @@ internal sealed class IncrementalPathState {
         override val cardinality: Int get() = arr.mappings.size
 
         override fun process(segment: SegmentsList.Segment) {
+            // TODO(perf): this delta's the segments list twice, can be optimised
             val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)
@@ -188,6 +193,7 @@ internal sealed class IncrementalPathState {
         override val cardinality: Int get() = arr.mappings.size
 
         override fun process(segment: SegmentsList.Segment) {
+            // TODO(perf): this delta's the segments list twice, can be optimised
             val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -19,7 +19,13 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
+        override fun process(segment: SegmentsList.Segment) {
+            val delta = delta(segment)
+            segments.insert(segment)
+            arr.addAll(delta)
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
             val delta = segments.newPathsOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
             // only accepting all paths that adhere to the constraints above: if one represents a binding, it gets
@@ -30,14 +36,14 @@ internal sealed class IncrementalPathState {
             if (segment.start != segment.end && segment.end !in segments.nodes) {
                 delta.add(mappingOf(start.name to segment.end, end.name to segment.end))
             }
-            segments.insert(segment)
-            arr.addAll(delta)
             return delta
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return arr.join(mappings)
         }
+
+        override fun toString() = segments.toString()
 
     }
 
@@ -51,12 +57,15 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            val delta = segments.newReachableStartNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(start.name to it) }
+        override fun process(segment: SegmentsList.Segment) {
+            val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)
-            return delta
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+            return segments.newReachableStartNodesOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(start.name to it) }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -75,12 +84,15 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            val delta = segments.newReachableEndNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(end.name to it) }
+        override fun process(segment: SegmentsList.Segment) {
+            val delta = delta(segment)
             segments.insert(segment)
             arr.addAll(delta)
-            return delta
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+            return segments.newReachableEndNodesOnAdding(segment)
+                .mapTo(ArrayList()) { mappingOf(end.name to it) }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -98,9 +110,14 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = if (satisfied) 1 else 0
 
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
+        override fun process(segment: SegmentsList.Segment) {
+            satisfied = true
+        }
+
+        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+            // it's expected that a call to `process` will happen soon after,
+            //  so not changing it here
             return if (!satisfied) {
-                satisfied = true
                 listOf(emptyMapping())
             } else {
                 emptyList()
@@ -113,105 +130,107 @@ internal sealed class IncrementalPathState {
 
     }
 
-    class OneOrMoreBinding(
-        val start: Pattern.Binding,
-        val end: Pattern.Binding
-    ) : IncrementalPathState() {
-
-        private val segments = SegmentsList()
-        private val arr = mutableJoinCollection(start.name, end.name)
-
-        override val cardinality: Int get() = arr.mappings.size
-
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            val delta = segments.newPathsOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
-            segments.insert(segment)
-            arr.addAll(delta)
-            return delta
-        }
-
-        override fun join(mappings: List<Mapping>): List<Mapping> {
-            return arr.join(mappings)
-        }
-
-    }
-
-    class OneOrMoreBindingExact(
-        val start: Pattern.Binding,
-        val end: Pattern.Exact
-    ) : IncrementalPathState() {
-
-        private val segments = SegmentsList()
-        private val arr = mutableJoinCollection(start.name)
-
-        override val cardinality: Int get() = arr.mappings.size
-
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            val delta = segments.newReachableStartNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(start.name to it) }
-            segments.insert(segment)
-            arr.addAll(delta)
-            return delta
-        }
-
-        override fun join(mappings: List<Mapping>): List<Mapping> {
-            return arr.join(mappings)
-        }
-
-    }
-
-    class OneOrMoreExactBinding(
-        val start: Pattern.Exact,
-        val end: Pattern.Binding
-    ) : IncrementalPathState() {
-
-        private val segments = SegmentsList()
-        private val arr = mutableJoinCollection(end.name)
-
-        override val cardinality: Int get() = arr.mappings.size
-
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            val delta = segments.newReachableEndNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(end.name to it) }
-            segments.insert(segment)
-            arr.addAll(delta)
-            return delta
-        }
-
-        override fun join(mappings: List<Mapping>): List<Mapping> {
-            return arr.join(mappings)
-        }
-
-    }
-
-    class OneOrMoreExact(
-        val start: Pattern.Exact,
-        val end: Pattern.Exact
-    ) : IncrementalPathState() {
-
-        private var satisfied = false
-
-        override val cardinality: Int get() = if (satisfied) 1 else 0
-
-        override fun insert(segment: SegmentsList.Segment): List<Mapping> {
-            return if (!satisfied) {
-                satisfied = true
-                listOf(emptyMapping())
-            } else {
-                emptyList()
-            }
-        }
-
-        override fun join(mappings: List<Mapping>): List<Mapping> {
-            return if (satisfied) mappings else emptyList()
-        }
-
-    }
+//    class OneOrMoreBinding(
+//        val start: Pattern.Binding,
+//        val end: Pattern.Binding
+//    ) : IncrementalPathState() {
+//
+//        private val segments = SegmentsList()
+//        private val arr = mutableJoinCollection(start.name, end.name)
+//
+//        override val cardinality: Int get() = arr.mappings.size
+//
+//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
+//            val delta = segments.newPathsOnAdding(segment)
+//                .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
+//            segments.insert(segment)
+//            arr.addAll(delta)
+//            return delta
+//        }
+//
+//        override fun join(mappings: List<Mapping>): List<Mapping> {
+//            return arr.join(mappings)
+//        }
+//
+//    }
+//
+//    class OneOrMoreBindingExact(
+//        val start: Pattern.Binding,
+//        val end: Pattern.Exact
+//    ) : IncrementalPathState() {
+//
+//        private val segments = SegmentsList()
+//        private val arr = mutableJoinCollection(start.name)
+//
+//        override val cardinality: Int get() = arr.mappings.size
+//
+//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
+//            val delta = segments.newReachableStartNodesOnAdding(segment)
+//                .mapTo(ArrayList()) { mappingOf(start.name to it) }
+//            segments.insert(segment)
+//            arr.addAll(delta)
+//            return delta
+//        }
+//
+//        override fun join(mappings: List<Mapping>): List<Mapping> {
+//            return arr.join(mappings)
+//        }
+//
+//    }
+//
+//    class OneOrMoreExactBinding(
+//        val start: Pattern.Exact,
+//        val end: Pattern.Binding
+//    ) : IncrementalPathState() {
+//
+//        private val segments = SegmentsList()
+//        private val arr = mutableJoinCollection(end.name)
+//
+//        override val cardinality: Int get() = arr.mappings.size
+//
+//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
+//            val delta = segments.newReachableEndNodesOnAdding(segment)
+//                .mapTo(ArrayList()) { mappingOf(end.name to it) }
+//            segments.insert(segment)
+//            arr.addAll(delta)
+//            return delta
+//        }
+//
+//        override fun join(mappings: List<Mapping>): List<Mapping> {
+//            return arr.join(mappings)
+//        }
+//
+//    }
+//
+//    class OneOrMoreExact(
+//        val start: Pattern.Exact,
+//        val end: Pattern.Exact
+//    ) : IncrementalPathState() {
+//
+//        private var satisfied = false
+//
+//        override val cardinality: Int get() = if (satisfied) 1 else 0
+//
+//        override fun process(segment: SegmentsList.Segment): List<Mapping> {
+//            return if (!satisfied) {
+//                satisfied = true
+//                listOf(emptyMapping())
+//            } else {
+//                emptyList()
+//            }
+//        }
+//
+//        override fun join(mappings: List<Mapping>): List<Mapping> {
+//            return if (satisfied) mappings else emptyList()
+//        }
+//
+//    }
 
     abstract val cardinality: Int
 
-    abstract fun insert(segment: SegmentsList.Segment): List<Mapping>
+    abstract fun process(segment: SegmentsList.Segment)
+
+    abstract fun delta(segment: SegmentsList.Segment): List<Mapping>
 
     abstract fun join(mappings: List<Mapping>): List<Mapping>
 
@@ -231,11 +250,11 @@ internal sealed class IncrementalPathState {
         fun oneOrMore(
             start: Pattern.Subject,
             end: Pattern.Object
-        ) = when {
-            start is Pattern.Exact && end is Pattern.Exact -> OneOrMoreExact(start, end)
-            start is Pattern.Binding && end is Pattern.Binding -> OneOrMoreBinding(start, end)
-            start is Pattern.Exact && end is Pattern.Binding -> OneOrMoreExactBinding(start, end)
-            start is Pattern.Binding && end is Pattern.Exact -> OneOrMoreBindingExact(start, end)
+        ) : Nothing = when {
+//            start is Pattern.Exact && end is Pattern.Exact -> OneOrMoreExact(start, end)
+//            start is Pattern.Binding && end is Pattern.Binding -> OneOrMoreBinding(start, end)
+//            start is Pattern.Exact && end is Pattern.Binding -> OneOrMoreExactBinding(start, end)
+//            start is Pattern.Binding && end is Pattern.Exact -> OneOrMoreBindingExact(start, end)
             else -> throw IllegalStateException("Unknown subject / pattern combination for `OneOrMore` predicate construct: $start -> $end")
         }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
@@ -13,7 +13,7 @@ import dev.tesserakt.sparql.runtime.incremental.types.SegmentsList
 
 internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
     protected val s: Pattern.Subject, protected val p: P, protected val o: Pattern.Object
-): JoinStateType {
+): MutableJoinState {
 
     final override val bindings: Set<String> = bindingNamesOf(s, p, o)
 
@@ -262,8 +262,7 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
                 start = end.toSubject()
             }
             chain.add(Pattern(start, p.chain.last(), o))
-            // FIXME
-            tree = JoinTree.None(chain)
+            tree = JoinTree(chain)
         }
 
         override fun process(quad: Quad) {
@@ -302,8 +301,7 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
                 start = end.toSubject()
             }
             chain.add(Pattern(start, pred.chain.last(), obj))
-            // FIXME
-            tree = JoinTree.None(chain)
+            tree = JoinTree(chain)
         }
 
         override fun process(quad: Quad) {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
@@ -10,7 +10,6 @@ import dev.tesserakt.sparql.runtime.core.pattern.bindingName
 import dev.tesserakt.sparql.runtime.core.pattern.matches
 import dev.tesserakt.sparql.runtime.incremental.collection.HashJoinArray
 import dev.tesserakt.sparql.runtime.incremental.types.SegmentsList
-import dev.tesserakt.sparql.runtime.util.Bitmask
 
 internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
     protected val s: Pattern.Subject, protected val p: P, protected val o: Pattern.Object
@@ -34,18 +33,15 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
 
         override val cardinality get() = data.mappings.size
 
-        final override fun insert(quad: Quad): List<Mapping> {
+        final override fun process(quad: Quad) {
             val new = delta(quad)
             data.addAll(new)
-            return new
         }
 
         final override fun join(mappings: List<Mapping>): List<Mapping> {
             Debug.onArrayPatternJoinExecuted()
             return data.join(mappings)
         }
-
-        protected abstract fun delta(quad: Quad): List<Mapping>
 
     }
 
@@ -144,12 +140,20 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
 
         private val predicate = pred.element
 
-        override fun insert(quad: Quad): List<Mapping> {
+        override fun process(quad: Quad) {
+            if (!predicate.matches(quad.p)) {
+                return
+            }
+            val segment = SegmentsList.Segment(start = quad.s, end = quad.o)
+            state.process(segment)
+        }
+
+        override fun delta(quad: Quad): List<Mapping> {
             if (!predicate.matches(quad.p)) {
                 return emptyList()
             }
             val segment = SegmentsList.Segment(start = quad.s, end = quad.o)
-            return state.insert(segment)
+            return state.delta(segment)
         }
     }
 
@@ -161,15 +165,29 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
 
         private val predicate = Pattern(s, p.element, o).createIncrementalPatternState()
 
-        override fun insert(quad: Quad): List<Mapping> {
-            val inner = predicate.insert(quad)
-            val segments = inner.map {
+        override fun process(quad: Quad) {
+            val new = predicate.delta(quad)
+            val segments = new.map {
                 SegmentsList.Segment(
                     start = this@StatefulRepeatingPattern.s.getTermOrNull(it)!!,
                     end = this@StatefulRepeatingPattern.o.getTermOrNull(it)!!
                 )
             }
-            return segments.flatMap { segment -> state.insert(segment) }
+            predicate.process(quad)
+            segments.forEach { segment -> state.process(segment) }
+        }
+
+        override fun delta(quad: Quad): List<Mapping> {
+            val new = predicate.delta(quad)
+            val segments = new.map {
+                SegmentsList.Segment(
+                    start = this@StatefulRepeatingPattern.s.getTermOrNull(it)!!,
+                    end = this@StatefulRepeatingPattern.o.getTermOrNull(it)!!
+                )
+            }
+            return segments
+                .flatMapTo(mutableSetOf()) { segment -> state.delta(segment) }
+                .toList()
         }
 
     }
@@ -182,13 +200,14 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
 
         private val states = p.allowed.map { p -> Pattern(s, p, o).createIncrementalPatternState() }
 
-        private val mappings = mutableListOf<Mapping>()
-        override val cardinality: Int get() = mappings.size
+        override val cardinality: Int get() = states.sumOf { it.cardinality }
 
-        override fun insert(quad: Quad): List<Mapping> {
-            val new = states.flatMap { it.insert(quad) }
-            mappings.addAll(new)
-            return new
+        override fun process(quad: Quad) {
+            states.forEach { it.process(quad) }
+        }
+
+        override fun delta(quad: Quad): List<Mapping> {
+            return states.flatMap { it.delta(quad) }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -205,13 +224,14 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
 
         private val states = p.allowed.map { p -> Pattern(s, p, o).createIncrementalPatternState() }
 
-        private val mappings = mutableListOf<Mapping>()
-        override val cardinality: Int get() = mappings.size
+        override val cardinality: Int get() = states.sumOf { it.cardinality }
 
-        override fun insert(quad: Quad): List<Mapping> {
-            val new = states.flatMap { it.insert(quad) }
-            mappings.addAll(new)
-            return new
+        override fun process(quad: Quad) {
+            states.forEach { it.process(quad) }
+        }
+
+        override fun delta(quad: Quad): List<Mapping> {
+            return states.flatMap { it.delta(quad) }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -226,38 +246,36 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
         o: Pattern.Object
     ) : IncrementalTriplePatternState<Pattern.Sequence>(s, p, o) {
 
-        private val chain: List<IncrementalTriplePatternState<*>>
+        private val tree: JoinTree
 
         private val mappings = mutableListOf<Mapping>()
         override val cardinality: Int get() = mappings.size
 
         init {
             require(p.chain.size > 1)
-            chain = ArrayList(p.chain.size)
+            val chain = ArrayList<Pattern>(p.chain.size)
             var start = s
             (0 until p.chain.size - 1).forEach { i ->
                 val p = p.chain[i]
                 val end = generateBinding()
-                chain.add(Pattern(start, p, end).createIncrementalPatternState())
+                chain.add(Pattern(start, p, end))
                 start = end.toSubject()
             }
-            chain.add(Pattern(start, p.chain.last(), o).createIncrementalPatternState())
+            chain.add(Pattern(start, p.chain.last(), o))
+            // FIXME
+            tree = JoinTree.None(chain)
         }
 
-        override fun insert(quad: Quad): List<Mapping> {
-            // TODO: join tree
-            val new = chain
-                .mapIndexed { i, element -> Bitmask.onesAt(i, length = chain.size) to element.insert(quad) }
-                .merge()
-                .flatMap { (mask, mappings) ->
-                    mask.inv().fold(mappings) { results, i -> chain[i].join(results) }
-                }
-            mappings.addAll(new)
-            return new
+        override fun process(quad: Quad) {
+            tree.process(quad)
+        }
+
+        override fun delta(quad: Quad): List<Mapping> {
+            return tree.delta(quad)
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
-            return chain.fold(mappings) { results, element -> element.join(results) }
+            return tree.join(mappings)
         }
 
     }
@@ -268,39 +286,36 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
         obj: Pattern.Object
     ) : IncrementalTriplePatternState<Pattern.UnboundSequence>(subj, pred, obj) {
 
-        private val chain: List<IncrementalTriplePatternState<*>>
+        private val tree: JoinTree
 
         private val mappings = mutableListOf<Mapping>()
         override val cardinality: Int get() = mappings.size
 
         init {
             require(pred.chain.size > 1)
-            chain = ArrayList(pred.chain.size)
+            val chain = ArrayList<Pattern>(pred.chain.size)
             var start = subj
             (0 until pred.chain.size - 1).forEach { i ->
                 val p = pred.chain[i]
                 val end = generateBinding()
-                chain.add(Pattern(start, p, end).createIncrementalPatternState())
+                chain.add(Pattern(start, p, end))
                 start = end.toSubject()
             }
-            chain.add(Pattern(start, pred.chain.last(), obj).createIncrementalPatternState())
+            chain.add(Pattern(start, pred.chain.last(), obj))
+            // FIXME
+            tree = JoinTree.None(chain)
         }
 
-        override fun insert(quad: Quad): List<Mapping> {
-            // TODO: join tree
-            val new = chain
-                .mapIndexed { i, element -> Bitmask.onesAt(i, length = chain.size) to element.insert(quad) }
-                .merge()
-                .flatMap { (mask, mappings) ->
-                    mask.inv().fold(mappings) { results, i -> chain[i].join(results) }
-                }
-            mappings.addAll(new)
-            chain.forEach { it.insert(quad) }
-            return new
+        override fun process(quad: Quad) {
+            tree.process(quad)
+        }
+
+        override fun delta(quad: Quad): List<Mapping> {
+            return tree.delta(quad)
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
-            return chain.fold(mappings) { results, element -> element.join(results) }
+            return tree.join(mappings)
         }
 
     }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
@@ -2,7 +2,6 @@ package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.core.Mapping
-import dev.tesserakt.sparql.runtime.incremental.types.Segment
 import dev.tesserakt.sparql.runtime.incremental.types.SelectQuerySegment
 import dev.tesserakt.sparql.runtime.incremental.types.StatementsSegment
 import dev.tesserakt.sparql.runtime.incremental.types.Union
@@ -17,8 +16,12 @@ internal class IncrementalUnionState(union: Union): JoinStateType {
 
             override val bindings: Set<String> get() = state.bindings
 
-            override fun insert(quad: Quad): List<Mapping> {
-                return state.insert(quad)
+            override fun process(quad: Quad) {
+                return state.process(quad)
+            }
+
+            override fun delta(quad: Quad): List<Mapping> {
+                return state.delta(quad)
             }
 
             override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -31,7 +34,11 @@ internal class IncrementalUnionState(union: Union): JoinStateType {
 
             override val bindings: Set<String> = parent.query.output.map { it.name }.toSet()
 
-            override fun insert(quad: Quad): List<Mapping> {
+            override fun process(quad: Quad) {
+                TODO("Not yet implemented")
+            }
+
+            override fun delta(quad: Quad): List<Mapping> {
                 TODO("Not yet implemented")
             }
 
@@ -43,7 +50,9 @@ internal class IncrementalUnionState(union: Union): JoinStateType {
 
         abstract val bindings: Set<String>
 
-        abstract fun insert(quad: Quad): List<Mapping>
+        abstract fun delta(quad: Quad): List<Mapping>
+
+        abstract fun process(quad: Quad)
 
         abstract fun join(mappings: List<Mapping>): List<Mapping>
 
@@ -53,8 +62,12 @@ internal class IncrementalUnionState(union: Union): JoinStateType {
 
     override val bindings: Set<String> = buildSet { state.forEach { addAll(it.bindings) } }
 
-    override fun insert(quad: Quad): List<Mapping> {
-        return state.flatMap { it.insert(quad) }
+    override fun process(quad: Quad) {
+        state.forEach { it.process(quad) }
+    }
+
+    override fun delta(quad: Quad): List<Mapping> {
+        return state.flatMap { it.delta(quad) }
     }
 
     override fun join(mappings: List<Mapping>): List<Mapping> {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
@@ -7,20 +7,18 @@ import dev.tesserakt.sparql.runtime.incremental.types.SelectQuerySegment
 import dev.tesserakt.sparql.runtime.incremental.types.StatementsSegment
 import dev.tesserakt.sparql.runtime.incremental.types.Union
 
-internal class IncrementalUnionState(union: Union) {
+internal class IncrementalUnionState(union: Union): JoinStateType {
 
-    sealed class Segment {
+    private sealed class Segment {
 
         class StatementsState(parent: StatementsSegment): Segment() {
 
             private val state = IncrementalBasicGraphPatternState(parent.statements)
 
-            override fun delta(quad: Quad): List<Mapping> {
-                return state.delta(quad)
-            }
+            override val bindings: Set<String> get() = state.bindings
 
-            override fun insert(quad: Quad) {
-                state.insert(quad)
+            override fun insert(quad: Quad): List<Mapping> {
+                return state.insert(quad)
             }
 
             override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -31,11 +29,9 @@ internal class IncrementalUnionState(union: Union) {
 
         class SubqueryState(parent: SelectQuerySegment): Segment() {
 
-            override fun delta(quad: Quad): List<Mapping> {
-                TODO("Not yet implemented")
-            }
+            override val bindings: Set<String> = parent.query.output.map { it.name }.toSet()
 
-            override fun insert(quad: Quad) {
+            override fun insert(quad: Quad): List<Mapping> {
                 TODO("Not yet implemented")
             }
 
@@ -45,9 +41,9 @@ internal class IncrementalUnionState(union: Union) {
 
         }
 
-        abstract fun delta(quad: Quad): List<Mapping>
+        abstract val bindings: Set<String>
 
-        abstract fun insert(quad: Quad)
+        abstract fun insert(quad: Quad): List<Mapping>
 
         abstract fun join(mappings: List<Mapping>): List<Mapping>
 
@@ -55,23 +51,24 @@ internal class IncrementalUnionState(union: Union) {
 
     private val state = union.map { it.createIncrementalSegmentState() }
 
-    fun delta(quad: Quad): List<Mapping> {
-        return state.flatMap { it.delta(quad) }
+    override val bindings: Set<String> = buildSet { state.forEach { addAll(it.bindings) } }
+
+    override fun insert(quad: Quad): List<Mapping> {
+        return state.flatMap { it.insert(quad) }
     }
 
-    fun insert(quad: Quad) {
-        return state.forEach { it.insert(quad) }
-    }
-
-    fun join(mappings: List<Mapping>): List<Mapping> {
+    override fun join(mappings: List<Mapping>): List<Mapping> {
         return state.flatMap { s -> s.join(mappings) }
     }
 
-}
+    companion object {
 
-/* helpers */
+        /* helpers */
 
-private fun Segment.createIncrementalSegmentState(): IncrementalUnionState.Segment = when (this) {
-    is SelectQuerySegment -> IncrementalUnionState.Segment.SubqueryState(this)
-    is StatementsSegment -> IncrementalUnionState.Segment.StatementsState(this)
+        private fun dev.tesserakt.sparql.runtime.incremental.types.Segment.createIncrementalSegmentState() = when (this) {
+            is SelectQuerySegment -> Segment.SubqueryState(this)
+            is StatementsSegment -> Segment.StatementsState(this)
+        }
+    }
+
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
@@ -6,7 +6,7 @@ import dev.tesserakt.sparql.runtime.incremental.types.SelectQuerySegment
 import dev.tesserakt.sparql.runtime.incremental.types.StatementsSegment
 import dev.tesserakt.sparql.runtime.incremental.types.Union
 
-internal class IncrementalUnionState(union: Union): JoinStateType {
+internal class IncrementalUnionState(union: Union): MutableJoinState {
 
     private sealed class Segment {
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinStateType.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinStateType.kt
@@ -1,0 +1,16 @@
+package dev.tesserakt.sparql.runtime.incremental.state
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.core.Mapping
+
+/**
+ * Represents a state type that can be joined with other states of the same (sub-) type, such as triple patterns or
+ *  union blocks.
+ */
+interface JoinStateType<J: JoinStateType<J>> {
+
+    fun join(other: J): List<Mapping>
+
+    fun insert(quad: Quad): List<Mapping>
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinStateType.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinStateType.kt
@@ -13,6 +13,14 @@ interface JoinStateType {
 
     fun join(mappings: List<Mapping>): List<Mapping>
 
-    fun insert(quad: Quad): List<Mapping>
+    /**
+     * Returns the delta the provided [quad] produces upon insertion
+     */
+    fun delta(quad: Quad): List<Mapping>
+
+    /**
+     * Processes an insertion of the [quad] to this state type
+     */
+    fun process(quad: Quad)
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinStateType.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinStateType.kt
@@ -7,9 +7,11 @@ import dev.tesserakt.sparql.runtime.core.Mapping
  * Represents a state type that can be joined with other states of the same (sub-) type, such as triple patterns or
  *  union blocks.
  */
-interface JoinStateType<J: JoinStateType<J>> {
+interface JoinStateType {
 
-    fun join(other: J): List<Mapping>
+    val bindings: Set<String>
+
+    fun join(mappings: List<Mapping>): List<Mapping>
 
     fun insert(quad: Quad): List<Mapping>
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
@@ -2,10 +2,14 @@ package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.types.Pattern
+import dev.tesserakt.sparql.runtime.common.util.Debug
 import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.incremental.collection.mutableJoinCollection
 import dev.tesserakt.sparql.runtime.incremental.state.IncrementalTriplePatternState.Companion.createIncrementalPatternState
+import dev.tesserakt.sparql.runtime.incremental.types.Patterns
 import dev.tesserakt.sparql.runtime.incremental.types.Union
 import dev.tesserakt.sparql.runtime.util.Bitmask
+import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmName
 
@@ -18,7 +22,7 @@ internal sealed interface JoinTree {
      * Non-existent join tree
      */
     @JvmInline
-    value class None<J: JoinStateType> private constructor(private val states: List<J>): JoinTree {
+    value class None<J: MutableJoinState>(private val states: List<J>): JoinTree {
 
         override fun delta(quad: Quad): List<Mapping> {
             val new = states
@@ -43,7 +47,7 @@ internal sealed interface JoinTree {
             }
         }
 
-        private fun join(completed: Bitmask, mappings: List<Mapping>): List<Mapping> {
+        fun join(completed: Bitmask, mappings: List<Mapping>): List<Mapping> {
             // as we only need to iterate over the patterns not yet managed, we need to inverse the bitmask
             //  before iterating over it
             return completed.inv().fold(mappings) { results, i ->
@@ -67,136 +71,198 @@ internal sealed interface JoinTree {
 
     }
 
-//    /**
-//     * A caching strategy only keeping intermediate mapping results cached that form a single chain starting from the
-//     *  very first element.
-//     */
-//    class LeftDeep(patterns: Patterns): JoinTree {
-//
-//        private val patterns = sort(patterns).map { it.createIncrementalPatternState() }
-//
-//        private val cache = buildList(patterns.size - 2) {
-//            val bindings = patterns[0].getAllNamedBindings().map { it.name }.toMutableSet()
-//            repeat(patterns.size - 2) { i ->
-//                bindings += patterns[i + 1].getAllNamedBindings().map { it.name }
-//                add(HashJoinArray(bindings = bindings))
-//            }
-//        }
-//
-//        override fun insert(quad: Quad): List<Mapping> {
-//            TODO("Not yet implemented")
-//        }
-//
-//        override fun join(mappings: List<Mapping>): List<Mapping> {
-//            TODO("Not yet implemented")
-//        }
-//
-//        private fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
-//            // we can't do much here
-//            if (mappings.isEmpty()) {
-//                return
-//            }
-//            // only saving those for which only a > 1 chain of LSBs are set (i.e. accepting 0b011, but not 0b010)
-//            //  but not those that are completely satisfied (complete solutions) as these can't be joined further
-//            val satisfied = bitmask.count()
-//            if (
-//                satisfied <= 1 ||
-//                bitmask.size() == satisfied ||
-//                bitmask.lowestZeroBitIndex() < bitmask.highestOneBitIndex()
-//            ) {
-//                return
-//            }
-//            // shifting the index by one as we don't cache 0b0..1
-//            val index = bitmask.highestOneBitIndex() - 1
-//            cache[index].addAll(mappings)
-//        }
-//
-//        private fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache(): List<Pair<Bitmask, List<Mapping>>> {
-//            // we can join every mapping for which it's bitmask has trailing zeroes (LSB):
-//            // * the result for a mask 0b0100 can be grown with cached element 0b0011, yielding 0b0111 (unsatisfied)
-//            //   as new intermediate result
-//            // * the result for a mask 0b0101 won't be changed, as there's no compatible cache item available
-//            return map { (mask, mappings) ->
-//                // mask 0b0..1 isn't stored, so only applying cache when there's zeroes at 0..1+
-//                if (mask.lowestOneBitIndex() < 2) {
-//                    return@map mask to mappings
-//                }
-//                // getting its compatible cache variant, which is its highest one bit, minus 2:
-//                // * the index is shifted by one (see `insert`)
-//                // * we're interested in the zero before it (0b100 -> 0b011)
-//                val index = mask.lowestOneBitIndex() - 2
-//                val cached = cache.getOrNull(index)
-//                    // wasn't cached (no valid combination found thus far)
-//                    ?: run {
-//                        Debug.onJoinTreeMiss()
-//                        return@map mask to mappings
-//                    }
-//                val result = cached.join(mappings)
-//                Debug.onJoinTreeHit(result.size)
-//                // forming the new mask this result adheres to, which is
-//                //  the original mask | ones (index based length)
-//                val satisfied = Bitmask.wrap((1 shl (index + 2)) - 1, length = mask.size())
-//                val total = mask or satisfied
-//                total to result
-//            }
-//        }
-//
-//        companion object {
-//
-//            private fun sort(patterns: Patterns): Patterns {
-//                if (patterns.isEmpty()) {
-//                    return Patterns(emptyList())
-//                }
-//                val bindings = patterns.associateWith { it.getAllNamedBindings().map { it.name } }.toMutableMap()
-//                // the first pattern part of the results is the one referencing the most common binding, whilst containing
-//                //  the least amount of other bindings of its own
-//                val all = bindings.values.flatten().distinct()
-//                if (all.isEmpty()) {
-//                    // no bindings in this query, skipping...
-//                    return Patterns(patterns)
-//                }
-//                val maxBindingOccurrence = all
-//                    .maxOf { binding -> bindings.values.count { binding in it } }
-//                val mostCommon = all
-//                    .filter { binding -> bindings.values.count { binding in it } == maxBindingOccurrence }.toSet()
-//                val first = bindings
-//                    .maxBy { it.value.count { patternBinding -> patternBinding in mostCommon } - it.value.size }
-//                val result = mutableListOf(first.key)
-//                // always incrementing the value of "how explored" a binding is based on the # of other bindings are present
-//                //  in the newly added pattern instance; 3 being the max amount of bindings in a single pattern instance
-//                val exploredBias = first.value.associateWith { 3 - first.value.size }.toMutableMap()
-//                bindings.remove(first.key)
-//                // with the first pattern inserted, the rest follow based on the order of inserting the least new bindings,
-//                //  having the most already in common with those already explored, and introducing bindings that are already
-//                //  most popular
-//                while (bindings.isNotEmpty()) {
-//                    // getting the next item that has (ordered by priority)
-//                    // the most bindings in common with those explored in large amounts
-//                    // the least # of bindings
-//                    val (nextPattern, nextBindings) = bindings.maxBy { (_, bindings) ->
-//                        val relevance = bindings.fold(3f - bindings.size) { a, b -> exploredBias[b]?.times(a) ?: (a / 2f) }
-//                        relevance
-//                    }
-//                    // further adapting the exploration bias using the same logic as the first pattern
-//                    nextBindings.forEach {
-//                        exploredBias[it] = exploredBias.getOrElse(it) { 0 } + (3 - nextBindings.size)
-//                    }
-//                    bindings.remove(nextPattern)
-//                    result.add(nextPattern)
-//                }
-//                return Patterns(result)
-//            }
-//
-//        }
-//
-//        override fun debugInformation() = buildString {
-//            appendLine(" * Join tree statistics (LeftDeep)")
-//            cache.forEachIndexed { i, cache ->
-//                appendLine("\tTree element ${i + 1} has cardinality ${cache?.size}")
-//            }
-//        }
-//
-//    }
+    /**
+     * A caching strategy only keeping intermediate mapping results cached that form a single chain starting from the
+     *  very first element.
+     */
+    class LeftDeep<J: MutableJoinState>(private val states: List<J>): JoinTree {
+
+        private val cache = buildList(states.size - 2) {
+            val available = mutableSetOf<String>()
+            available.addAll(states[0].bindings)
+            available.addAll(states[1].bindings)
+            repeat(states.size - 2) { i ->
+                val next = states[i + 2].bindings
+                add(mutableJoinCollection(bindings = next.intersect(available)))
+                available += next
+            }
+        }
+
+        // using a fallback "none" join tree type to fill in the gaps after applying the left deep cache
+        private val fallback = None(states)
+
+        override fun delta(quad: Quad): List<Mapping> {
+            return states
+                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = states.size) to pattern.delta(quad) }
+                .expandResultSet()
+                .flatMap { (completed, mappings) -> join(completed, mappings) }
+        }
+
+        override fun process(quad: Quad) {
+            // first recalculating the delta for the quad, inserting all intermediate results
+            states
+                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = states.size) to pattern.delta(quad) }
+                .expandResultSet()
+                // now iterating over every new individual result
+                .forEach individualResult@ { (completed, mappings) ->
+                    // first inserting the expanded result as is, could be already relevant on its own
+                    insert(completed, mappings)
+                    // now accelerating using the tree, these new results can then be inserted as-is
+                    var (mask, results) = joinUsingTree(completed, mappings)
+                    // continuing one-by-one to further extend the tree completely, which the mask should allow
+                    //  for based on the `joinUsingTree` already limiting its result to those with 0b...1 variants
+                    mask.inv().forEach { i ->
+                        if (results.isEmpty()) return@individualResult
+                        insert(mask, results)
+                        mask = mask.withOnesAt(i)
+                        results = states[i].join(results)
+                    }
+                }
+            // now also updating the individual states
+            states.forEach { it.process(quad) }
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return join(completed = Bitmask.wrap(0, length = states.size), mappings)
+        }
+
+        fun join(completed: Bitmask, mappings: List<Mapping>): List<Mapping> {
+            val (mask, results) = joinUsingTree(completed, mappings)
+            return fallback.join(mask, results)
+        }
+
+        fun joinUsingTree(completed: Bitmask, mappings: List<Mapping>): Pair<Bitmask, List<Mapping>> {
+            // mask 0b0..1 isn't stored, so only applying cache when there's zeroes at 0..1+
+            if (completed.lowestOneBitIndex() < 2) {
+                return completed to mappings
+            }
+            // we can join every mapping for which it's bitmask has trailing zeroes (LSB):
+            // * the result for a mask 0b0100 can be grown with cached element 0b0011, yielding 0b0111 (unsatisfied)
+            //   as new intermediate result
+            // * the result for a mask 0b0101 won't be changed, as there's no compatible cache item available
+            // getting its compatible cache variant, which is its lowest one bit, minus 2:
+            // * the index is shifted by one (see `insert`)
+            // * we're interested in the zero before it (0b100 -> 0b011)
+            val index = completed.lowestOneBitIndex() - 2
+            val cached = cache.getOrNull(index)
+                // wasn't cached (no valid combination found thus far, so no results available)
+                ?: run {
+                    Debug.onJoinTreeMiss()
+                    return completed to emptyList()
+                }
+            val result = cached.join(mappings)
+            Debug.onJoinTreeHit(result.size)
+            // forming the new mask this result adheres to, which is
+            //  the original mask | ones (index based length)
+            val satisfied = Bitmask.wrap((1 shl (index + 2)) - 1, length = states.size)
+            val total = completed or satisfied
+            return total to result
+        }
+
+        private fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
+            // we can't do much here
+            if (mappings.isEmpty()) {
+                return
+            }
+            // only saving those for which only a > 1 chain of LSBs are set (i.e. accepting 0b011, but not 0b010)
+            //  but not those that are completely satisfied (complete solutions) as these can't be joined further
+            val satisfied = bitmask.count()
+            if (
+                satisfied <= 1 ||
+                bitmask.size() == satisfied ||
+                bitmask.lowestZeroBitIndex() < bitmask.highestOneBitIndex()
+            ) {
+                return
+            }
+            // shifting the index by one as we don't cache 0b0..1
+            val index = bitmask.highestOneBitIndex() - 1
+            cache[index].addAll(mappings)
+        }
+
+        companion object {
+
+            private fun sort(patterns: List<Pattern>): Patterns {
+                if (patterns.isEmpty()) {
+                    return Patterns(emptyList())
+                }
+                val bindings = patterns.associateWith { it.getAllNamedBindings().map { it.name } }.toMutableMap()
+                // the first pattern part of the results is the one referencing the most common binding, whilst containing
+                //  the least amount of other bindings of its own
+                val all = bindings.values.flatten().distinct()
+                if (all.isEmpty()) {
+                    // no bindings in this query, skipping...
+                    return Patterns(patterns)
+                }
+                val maxBindingOccurrence = all
+                    .maxOf { binding -> bindings.values.count { binding in it } }
+                val mostCommon = all
+                    .filter { binding -> bindings.values.count { binding in it } == maxBindingOccurrence }.toSet()
+                val first = bindings
+                    .maxBy { it.value.count { patternBinding -> patternBinding in mostCommon } - it.value.size }
+                val result = mutableListOf(first.key)
+                // always incrementing the value of "how explored" a binding is based on the # of other bindings are present
+                //  in the newly added pattern instance; 3 being the max amount of bindings in a single pattern instance
+                val exploredBias = first.value.associateWith { 3 - first.value.size }.toMutableMap()
+                bindings.remove(first.key)
+                // with the first pattern inserted, the rest follow based on the order of inserting the least new bindings,
+                //  having the most already in common with those already explored, and introducing bindings that are already
+                //  most popular
+                while (bindings.isNotEmpty()) {
+                    // getting the next item that has (ordered by priority)
+                    // the most bindings in common with those explored in large amounts
+                    // the least # of bindings
+                    val (nextPattern, nextBindings) = bindings.maxBy { (_, bindings) ->
+                        val relevance = bindings.fold(3f - bindings.size) { a, b -> exploredBias[b]?.times(a) ?: (a / 2f) }
+                        relevance
+                    }
+                    // further adapting the exploration bias using the same logic as the first pattern
+                    nextBindings.forEach {
+                        exploredBias[it] = exploredBias.getOrElse(it) { 0 } + (3 - nextBindings.size)
+                    }
+                    bindings.remove(nextPattern)
+                    result.add(nextPattern)
+                }
+                return Patterns(result)
+            }
+
+            @JvmName("forPatterns")
+            operator fun invoke(patterns: List<Pattern>) = LeftDeep(
+                states = sort(patterns).map { it.createIncrementalPatternState() }
+            )
+
+            @JvmName("forUnions")
+            operator fun invoke(unions: List<Union>) = LeftDeep(
+                states = unions.map { IncrementalUnionState(it) }
+            )
+
+        }
+
+        override fun debugInformation() = buildString {
+            appendLine(" * Join tree statistics (LeftDeep)")
+            // first line
+            appendLine("    ${states.first()}")
+            // middle lines
+            (1 until states.size - 1).forEach { i ->
+                append("   ")
+                append("  ".repeat(i))
+                append('└')
+                append("|| ")
+                appendLine(states[i])
+                append("   ")
+                append("  ".repeat(i))
+                append(' ')
+                append("|| ")
+                appendLine("joined into ${cache[i - 1]})")
+            }
+            // final line (doesn't have its own state)
+            append("    ")
+            append("  ".repeat(states.size - 1))
+            append('└')
+            append(' ')
+            appendLine(states.last())
+        }
+
+    }
 
     /**
      * Returns the new [Mapping]s that are obtained when [insert]ing the [quad] in child states part of the tree, without
@@ -218,5 +284,24 @@ internal sealed interface JoinTree {
      * Returns a string containing debug information (runtime statistics)
      */
     fun debugInformation(): String = " * Join tree statistics unavailable (implementation: ${this::class.simpleName})"
+
+    companion object {
+
+
+        @JvmName("forPatterns")
+        operator fun invoke(patterns: List<Pattern>) = when {
+            // TODO also based on binding overlap
+            patterns.size >= 3 -> LeftDeep(patterns)
+            else -> None(patterns)
+        }
+
+        @JvmName("forUnions")
+        operator fun invoke(unions: List<Union>) = when {
+            // TODO also based on binding overlap
+            unions.size >= 3 -> LeftDeep(unions)
+            else -> None(unions)
+        }
+
+    }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
@@ -1,15 +1,13 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.runtime.common.util.Debug
+import dev.tesserakt.sparql.runtime.common.types.Pattern
 import dev.tesserakt.sparql.runtime.core.Mapping
-import dev.tesserakt.sparql.runtime.incremental.collection.HashJoinArray
 import dev.tesserakt.sparql.runtime.incremental.state.IncrementalTriplePatternState.Companion.createIncrementalPatternState
-import dev.tesserakt.sparql.runtime.incremental.types.Patterns
 import dev.tesserakt.sparql.runtime.incremental.types.Union
 import dev.tesserakt.sparql.runtime.util.Bitmask
-import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmName
 
 /**
  * A general join tree type, containing intermediate joined values depending on the tree implementation
@@ -22,12 +20,16 @@ internal sealed interface JoinTree {
     @JvmInline
     value class None<J: JoinStateType> private constructor(private val states: List<J>): JoinTree {
 
-        override fun insert(quad: Quad): List<Mapping> {
+        override fun delta(quad: Quad): List<Mapping> {
             val new = states
-                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = states.size) to pattern.insert(quad) }
-                .merge()
+                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = states.size) to pattern.delta(quad) }
+                .expandResultSet()
                 .flatMap { (completed, mappings) -> join(completed, mappings) }
             return new
+        }
+
+        override fun process(quad: Quad) {
+            states.forEach { it.process(quad) }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -51,10 +53,12 @@ internal sealed interface JoinTree {
 
         companion object {
 
-            operator fun invoke(patterns: Patterns) = None(
+            @JvmName("forPatterns")
+            operator fun invoke(patterns: List<Pattern>) = None(
                 states = patterns.map { it.createIncrementalPatternState() }
             )
 
+            @JvmName("forUnions")
             operator fun invoke(unions: List<Union>) = None(
                 states = unions.map { IncrementalUnionState(it) }
             )
@@ -63,141 +67,147 @@ internal sealed interface JoinTree {
 
     }
 
+//    /**
+//     * A caching strategy only keeping intermediate mapping results cached that form a single chain starting from the
+//     *  very first element.
+//     */
+//    class LeftDeep(patterns: Patterns): JoinTree {
+//
+//        private val patterns = sort(patterns).map { it.createIncrementalPatternState() }
+//
+//        private val cache = buildList(patterns.size - 2) {
+//            val bindings = patterns[0].getAllNamedBindings().map { it.name }.toMutableSet()
+//            repeat(patterns.size - 2) { i ->
+//                bindings += patterns[i + 1].getAllNamedBindings().map { it.name }
+//                add(HashJoinArray(bindings = bindings))
+//            }
+//        }
+//
+//        override fun insert(quad: Quad): List<Mapping> {
+//            TODO("Not yet implemented")
+//        }
+//
+//        override fun join(mappings: List<Mapping>): List<Mapping> {
+//            TODO("Not yet implemented")
+//        }
+//
+//        private fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
+//            // we can't do much here
+//            if (mappings.isEmpty()) {
+//                return
+//            }
+//            // only saving those for which only a > 1 chain of LSBs are set (i.e. accepting 0b011, but not 0b010)
+//            //  but not those that are completely satisfied (complete solutions) as these can't be joined further
+//            val satisfied = bitmask.count()
+//            if (
+//                satisfied <= 1 ||
+//                bitmask.size() == satisfied ||
+//                bitmask.lowestZeroBitIndex() < bitmask.highestOneBitIndex()
+//            ) {
+//                return
+//            }
+//            // shifting the index by one as we don't cache 0b0..1
+//            val index = bitmask.highestOneBitIndex() - 1
+//            cache[index].addAll(mappings)
+//        }
+//
+//        private fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache(): List<Pair<Bitmask, List<Mapping>>> {
+//            // we can join every mapping for which it's bitmask has trailing zeroes (LSB):
+//            // * the result for a mask 0b0100 can be grown with cached element 0b0011, yielding 0b0111 (unsatisfied)
+//            //   as new intermediate result
+//            // * the result for a mask 0b0101 won't be changed, as there's no compatible cache item available
+//            return map { (mask, mappings) ->
+//                // mask 0b0..1 isn't stored, so only applying cache when there's zeroes at 0..1+
+//                if (mask.lowestOneBitIndex() < 2) {
+//                    return@map mask to mappings
+//                }
+//                // getting its compatible cache variant, which is its highest one bit, minus 2:
+//                // * the index is shifted by one (see `insert`)
+//                // * we're interested in the zero before it (0b100 -> 0b011)
+//                val index = mask.lowestOneBitIndex() - 2
+//                val cached = cache.getOrNull(index)
+//                    // wasn't cached (no valid combination found thus far)
+//                    ?: run {
+//                        Debug.onJoinTreeMiss()
+//                        return@map mask to mappings
+//                    }
+//                val result = cached.join(mappings)
+//                Debug.onJoinTreeHit(result.size)
+//                // forming the new mask this result adheres to, which is
+//                //  the original mask | ones (index based length)
+//                val satisfied = Bitmask.wrap((1 shl (index + 2)) - 1, length = mask.size())
+//                val total = mask or satisfied
+//                total to result
+//            }
+//        }
+//
+//        companion object {
+//
+//            private fun sort(patterns: Patterns): Patterns {
+//                if (patterns.isEmpty()) {
+//                    return Patterns(emptyList())
+//                }
+//                val bindings = patterns.associateWith { it.getAllNamedBindings().map { it.name } }.toMutableMap()
+//                // the first pattern part of the results is the one referencing the most common binding, whilst containing
+//                //  the least amount of other bindings of its own
+//                val all = bindings.values.flatten().distinct()
+//                if (all.isEmpty()) {
+//                    // no bindings in this query, skipping...
+//                    return Patterns(patterns)
+//                }
+//                val maxBindingOccurrence = all
+//                    .maxOf { binding -> bindings.values.count { binding in it } }
+//                val mostCommon = all
+//                    .filter { binding -> bindings.values.count { binding in it } == maxBindingOccurrence }.toSet()
+//                val first = bindings
+//                    .maxBy { it.value.count { patternBinding -> patternBinding in mostCommon } - it.value.size }
+//                val result = mutableListOf(first.key)
+//                // always incrementing the value of "how explored" a binding is based on the # of other bindings are present
+//                //  in the newly added pattern instance; 3 being the max amount of bindings in a single pattern instance
+//                val exploredBias = first.value.associateWith { 3 - first.value.size }.toMutableMap()
+//                bindings.remove(first.key)
+//                // with the first pattern inserted, the rest follow based on the order of inserting the least new bindings,
+//                //  having the most already in common with those already explored, and introducing bindings that are already
+//                //  most popular
+//                while (bindings.isNotEmpty()) {
+//                    // getting the next item that has (ordered by priority)
+//                    // the most bindings in common with those explored in large amounts
+//                    // the least # of bindings
+//                    val (nextPattern, nextBindings) = bindings.maxBy { (_, bindings) ->
+//                        val relevance = bindings.fold(3f - bindings.size) { a, b -> exploredBias[b]?.times(a) ?: (a / 2f) }
+//                        relevance
+//                    }
+//                    // further adapting the exploration bias using the same logic as the first pattern
+//                    nextBindings.forEach {
+//                        exploredBias[it] = exploredBias.getOrElse(it) { 0 } + (3 - nextBindings.size)
+//                    }
+//                    bindings.remove(nextPattern)
+//                    result.add(nextPattern)
+//                }
+//                return Patterns(result)
+//            }
+//
+//        }
+//
+//        override fun debugInformation() = buildString {
+//            appendLine(" * Join tree statistics (LeftDeep)")
+//            cache.forEachIndexed { i, cache ->
+//                appendLine("\tTree element ${i + 1} has cardinality ${cache?.size}")
+//            }
+//        }
+//
+//    }
+
     /**
-     * A caching strategy only keeping intermediate mapping results cached that form a single chain starting from the
-     *  very first element.
+     * Returns the new [Mapping]s that are obtained when [insert]ing the [quad] in child states part of the tree, without
+     *  modifying the tree
      */
-    class LeftDeep(patterns: Patterns): JoinTree {
-
-        private val patterns = sort(patterns).map { it.createIncrementalPatternState() }
-
-        private val cache = buildList(patterns.size - 2) {
-            val bindings = patterns[0].getAllNamedBindings().map { it.name }.toMutableSet()
-            repeat(patterns.size - 2) { i ->
-                bindings += patterns[i + 1].getAllNamedBindings().map { it.name }
-                add(HashJoinArray(bindings = bindings))
-            }
-        }
-
-        override fun insert(quad: Quad): List<Mapping> {
-            TODO("Not yet implemented")
-        }
-
-        override fun join(mappings: List<Mapping>): List<Mapping> {
-            TODO("Not yet implemented")
-        }
-
-        private fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
-            // we can't do much here
-            if (mappings.isEmpty()) {
-                return
-            }
-            // only saving those for which only a > 1 chain of LSBs are set (i.e. accepting 0b011, but not 0b010)
-            //  but not those that are completely satisfied (complete solutions) as these can't be joined further
-            val satisfied = bitmask.count()
-            if (
-                satisfied <= 1 ||
-                bitmask.size() == satisfied ||
-                bitmask.lowestZeroBitIndex() < bitmask.highestOneBitIndex()
-            ) {
-                return
-            }
-            // shifting the index by one as we don't cache 0b0..1
-            val index = bitmask.highestOneBitIndex() - 1
-            cache[index].addAll(mappings)
-        }
-
-        private fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache(): List<Pair<Bitmask, List<Mapping>>> {
-            // we can join every mapping for which it's bitmask has trailing zeroes (LSB):
-            // * the result for a mask 0b0100 can be grown with cached element 0b0011, yielding 0b0111 (unsatisfied)
-            //   as new intermediate result
-            // * the result for a mask 0b0101 won't be changed, as there's no compatible cache item available
-            return map { (mask, mappings) ->
-                // mask 0b0..1 isn't stored, so only applying cache when there's zeroes at 0..1+
-                if (mask.lowestOneBitIndex() < 2) {
-                    return@map mask to mappings
-                }
-                // getting its compatible cache variant, which is its highest one bit, minus 2:
-                // * the index is shifted by one (see `insert`)
-                // * we're interested in the zero before it (0b100 -> 0b011)
-                val index = mask.lowestOneBitIndex() - 2
-                val cached = cache.getOrNull(index)
-                    // wasn't cached (no valid combination found thus far)
-                    ?: run {
-                        Debug.onJoinTreeMiss()
-                        return@map mask to mappings
-                    }
-                val result = cached.join(mappings)
-                Debug.onJoinTreeHit(result.size)
-                // forming the new mask this result adheres to, which is
-                //  the original mask | ones (index based length)
-                val satisfied = Bitmask.wrap((1 shl (index + 2)) - 1, length = mask.size())
-                val total = mask or satisfied
-                total to result
-            }
-        }
-
-        companion object {
-
-            private fun sort(patterns: Patterns): Patterns {
-                if (patterns.isEmpty()) {
-                    return Patterns(emptyList())
-                }
-                val bindings = patterns.associateWith { it.getAllNamedBindings().map { it.name } }.toMutableMap()
-                // the first pattern part of the results is the one referencing the most common binding, whilst containing
-                //  the least amount of other bindings of its own
-                val all = bindings.values.flatten().distinct()
-                if (all.isEmpty()) {
-                    // no bindings in this query, skipping...
-                    return Patterns(patterns)
-                }
-                val maxBindingOccurrence = all
-                    .maxOf { binding -> bindings.values.count { binding in it } }
-                val mostCommon = all
-                    .filter { binding -> bindings.values.count { binding in it } == maxBindingOccurrence }.toSet()
-                val first = bindings
-                    .maxBy { it.value.count { patternBinding -> patternBinding in mostCommon } - it.value.size }
-                val result = mutableListOf(first.key)
-                // always incrementing the value of "how explored" a binding is based on the # of other bindings are present
-                //  in the newly added pattern instance; 3 being the max amount of bindings in a single pattern instance
-                val exploredBias = first.value.associateWith { 3 - first.value.size }.toMutableMap()
-                bindings.remove(first.key)
-                // with the first pattern inserted, the rest follow based on the order of inserting the least new bindings,
-                //  having the most already in common with those already explored, and introducing bindings that are already
-                //  most popular
-                while (bindings.isNotEmpty()) {
-                    // getting the next item that has (ordered by priority)
-                    // the most bindings in common with those explored in large amounts
-                    // the least # of bindings
-                    val (nextPattern, nextBindings) = bindings.maxBy { (_, bindings) ->
-                        val relevance = bindings.fold(3f - bindings.size) { a, b -> exploredBias[b]?.times(a) ?: (a / 2f) }
-                        relevance
-                    }
-                    // further adapting the exploration bias using the same logic as the first pattern
-                    nextBindings.forEach {
-                        exploredBias[it] = exploredBias.getOrElse(it) { 0 } + (3 - nextBindings.size)
-                    }
-                    bindings.remove(nextPattern)
-                    result.add(nextPattern)
-                }
-                return Patterns(result)
-            }
-
-        }
-
-        override fun debugInformation() = buildString {
-            appendLine(" * Join tree statistics (LeftDeep)")
-            cache.forEachIndexed { i, cache ->
-                appendLine("\tTree element ${i + 1} has cardinality ${cache?.size}")
-            }
-        }
-
-    }
+    fun delta(quad: Quad): List<Mapping>
 
     /**
-     * Returns the new [Mapping]s that are obtained when [insert]ing the [quad] in child states part of the tree
+     * Inserts the [quad] in the child states, updating the tree
      */
-    fun insert(quad: Quad): List<Mapping>
+    fun process(quad: Quad)
 
     /**
      * Returns the result of [join]ing the [mappings] with its own internal state

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
@@ -1,57 +1,64 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
+import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.util.Debug
 import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.incremental.collection.HashJoinArray
+import dev.tesserakt.sparql.runtime.incremental.state.IncrementalTriplePatternState.Companion.createIncrementalPatternState
 import dev.tesserakt.sparql.runtime.incremental.types.Patterns
+import dev.tesserakt.sparql.runtime.incremental.types.Union
 import dev.tesserakt.sparql.runtime.util.Bitmask
 import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
+import kotlin.jvm.JvmInline
 
 /**
  * A general join tree type, containing intermediate joined values depending on the tree implementation
  */
-sealed class JoinTree {
+internal sealed interface JoinTree {
 
     /**
      * Non-existent join tree
      */
-    data object None: JoinTree() {
+    @JvmInline
+    value class None<J: JoinStateType> private constructor(private val states: List<J>): JoinTree {
 
-        override fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
-            // nothing to save, we don't cache anything
+        override fun insert(quad: Quad): List<Mapping> {
+            val new = states
+                .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = states.size) to pattern.insert(quad) }
+                .expandResultSet()
+                .flatMap { (completed, mappings) -> join(completed, mappings) }
+            return new
         }
 
-        // as we don't cache anything, the input becomes the output directly
-        override fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache() = this
-
-    }
-
-    /**
-     * Caches all intermediate joined values, does not behave as an actual tree.
-     */
-    class Full: JoinTree() {
-
-        private val cache = mutableMapOf<Bitmask, MutableList<Mapping>>()
-
-        override fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
-            cache.getOrPut(bitmask) { mutableListOf() }.addAll(mappings)
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return join(completed = Bitmask.wrap(0, length = states.size), mappings)
         }
 
-        // as we don't cache anything, the input becomes the output directly
-        override fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache(): List<Pair<Bitmask, List<Mapping>>> {
-            return map { (mask, mappings) ->
-                val remaining = mask.inv()
-                if (remaining.count() == 1) {
-                    // this one isn't cached, so leaving it alone
-                    return@map mask to mappings
-                }
-                val cached = cache[remaining]
-                val satisfied = Bitmask.wrap(raw = (1 shl (mask.size() + 1)) - 1, length = mask.size())
-                if (cached != null) {
-                    satisfied to doNestedJoin(cached, mappings)
-                } else {
-                    mask to mappings
-                }
+        override fun debugInformation() = buildString {
+            appendLine(" * Join tree statistics (None)")
+            states.forEachIndexed { i, state ->
+                appendLine("\tState element ${i + 1}: $state")
             }
+        }
+
+        private fun join(completed: Bitmask, mappings: List<Mapping>): List<Mapping> {
+            // as we only need to iterate over the patterns not yet managed, we need to inverse the bitmask
+            //  before iterating over it
+            return completed.inv().fold(mappings) { results, i ->
+                if (results.isEmpty()) return emptyList() else states[i].join(results)
+            }
+        }
+
+        companion object {
+
+            operator fun invoke(patterns: Patterns) = None(
+                states = patterns.map { it.createIncrementalPatternState() }
+            )
+
+            operator fun invoke(unions: List<Union>) = None(
+                states = unions.map { IncrementalUnionState(it) }
+            )
+
         }
 
     }
@@ -60,11 +67,27 @@ sealed class JoinTree {
      * A caching strategy only keeping intermediate mapping results cached that form a single chain starting from the
      *  very first element.
      */
-    class LeftDeep: JoinTree() {
+    class LeftDeep(patterns: Patterns): JoinTree {
 
-        private val cache = mutableListOf<HashJoinArray?>()
+        private val patterns = sort(patterns).map { it.createIncrementalPatternState() }
 
-        override fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
+        private val cache = buildList(patterns.size - 2) {
+            val bindings = patterns[0].getAllNamedBindings().map { it.name }.toMutableSet()
+            repeat(patterns.size - 2) { i ->
+                bindings += patterns[i + 1].getAllNamedBindings().map { it.name }
+                add(HashJoinArray(bindings = bindings))
+            }
+        }
+
+        override fun insert(quad: Quad): List<Mapping> {
+            TODO("Not yet implemented")
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            TODO("Not yet implemented")
+        }
+
+        private fun insert(bitmask: Bitmask, mappings: List<Mapping>) {
             // we can't do much here
             if (mappings.isEmpty()) {
                 return
@@ -81,17 +104,10 @@ sealed class JoinTree {
             }
             // shifting the index by one as we don't cache 0b0..1
             val index = bitmask.highestOneBitIndex() - 1
-            while (cache.size < index) {
-                cache.add(null)
-            }
-            if (cache.size == index) {
-                // all mappings should share binding names, so only using those of the first one
-                cache.add(HashJoinArray(mappings.first().keys))
-            }
-            cache[index]!!.addAll(mappings)
+            cache[index].addAll(mappings)
         }
 
-        override fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache(): List<Pair<Bitmask, List<Mapping>>> {
+        private fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache(): List<Pair<Bitmask, List<Mapping>>> {
             // we can join every mapping for which it's bitmask has trailing zeroes (LSB):
             // * the result for a mask 0b0100 can be grown with cached element 0b0011, yielding 0b0111 (unsatisfied)
             //   as new intermediate result
@@ -121,51 +137,55 @@ sealed class JoinTree {
             }
         }
 
-        override fun sorted(patterns: Patterns): Patterns {
-            if (patterns.isEmpty()) {
-                return Patterns(emptyList())
-            }
-            val bindings = patterns.associateWith { it.getAllNamedBindings().map { it.name } }.toMutableMap()
-            // the first pattern part of the results is the one referencing the most common binding, whilst containing
-            //  the least amount of other bindings of its own
-            val all = bindings.values.flatten().distinct()
-            if (all.isEmpty()) {
-                // no bindings in this query, skipping...
-                return Patterns(patterns)
-            }
-            val maxBindingOccurrence = all
-                .maxOf { binding -> bindings.values.count { binding in it } }
-            val mostCommon = all
-                .filter { binding -> bindings.values.count { binding in it } == maxBindingOccurrence }.toSet()
-            val first = bindings
-                .maxBy { it.value.count { patternBinding -> patternBinding in mostCommon } - it.value.size }
-            val result = mutableListOf(first.key)
-            // always incrementing the value of "how explored" a binding is based on the # of other bindings are present
-            //  in the newly added pattern instance; 3 being the max amount of bindings in a single pattern instance
-            val exploredBias = first.value.associateWith { 3 - first.value.size }.toMutableMap()
-            bindings.remove(first.key)
-            // with the first pattern inserted, the rest follow based on the order of inserting the least new bindings,
-            //  having the most already in common with those already explored, and introducing bindings that are already
-            //  most popular
-            while (bindings.isNotEmpty()) {
-                // getting the next item that has (ordered by priority)
-                // the most bindings in common with those explored in large amounts
-                // the least # of bindings
-                val (nextPattern, nextBindings) = bindings.maxBy { (_, bindings) ->
-                    val relevance = bindings.fold(3f - bindings.size) { a, b -> exploredBias[b]?.times(a) ?: (a / 2f) }
-                    relevance
+        companion object {
+
+            private fun sort(patterns: Patterns): Patterns {
+                if (patterns.isEmpty()) {
+                    return Patterns(emptyList())
                 }
-                // further adapting the exploration bias using the same logic as the first pattern
-                nextBindings.forEach {
-                    exploredBias[it] = exploredBias.getOrElse(it) { 0 } + (3 - nextBindings.size)
+                val bindings = patterns.associateWith { it.getAllNamedBindings().map { it.name } }.toMutableMap()
+                // the first pattern part of the results is the one referencing the most common binding, whilst containing
+                //  the least amount of other bindings of its own
+                val all = bindings.values.flatten().distinct()
+                if (all.isEmpty()) {
+                    // no bindings in this query, skipping...
+                    return Patterns(patterns)
                 }
-                bindings.remove(nextPattern)
-                result.add(nextPattern)
+                val maxBindingOccurrence = all
+                    .maxOf { binding -> bindings.values.count { binding in it } }
+                val mostCommon = all
+                    .filter { binding -> bindings.values.count { binding in it } == maxBindingOccurrence }.toSet()
+                val first = bindings
+                    .maxBy { it.value.count { patternBinding -> patternBinding in mostCommon } - it.value.size }
+                val result = mutableListOf(first.key)
+                // always incrementing the value of "how explored" a binding is based on the # of other bindings are present
+                //  in the newly added pattern instance; 3 being the max amount of bindings in a single pattern instance
+                val exploredBias = first.value.associateWith { 3 - first.value.size }.toMutableMap()
+                bindings.remove(first.key)
+                // with the first pattern inserted, the rest follow based on the order of inserting the least new bindings,
+                //  having the most already in common with those already explored, and introducing bindings that are already
+                //  most popular
+                while (bindings.isNotEmpty()) {
+                    // getting the next item that has (ordered by priority)
+                    // the most bindings in common with those explored in large amounts
+                    // the least # of bindings
+                    val (nextPattern, nextBindings) = bindings.maxBy { (_, bindings) ->
+                        val relevance = bindings.fold(3f - bindings.size) { a, b -> exploredBias[b]?.times(a) ?: (a / 2f) }
+                        relevance
+                    }
+                    // further adapting the exploration bias using the same logic as the first pattern
+                    nextBindings.forEach {
+                        exploredBias[it] = exploredBias.getOrElse(it) { 0 } + (3 - nextBindings.size)
+                    }
+                    bindings.remove(nextPattern)
+                    result.add(nextPattern)
+                }
+                return Patterns(result)
             }
-            return Patterns(result)
+
         }
 
-        override fun debugInfo() = buildString {
+        override fun debugInformation() = buildString {
             appendLine(" * Join tree statistics (LeftDeep)")
             cache.forEachIndexed { i, cache ->
                 appendLine("\tTree element ${i + 1} has cardinality ${cache?.size}")
@@ -175,23 +195,18 @@ sealed class JoinTree {
     }
 
     /**
-     * Processes the provided [mappings] associated with the satisfied [bitmask] for plan-based optimal caching
+     * Returns the new [Mapping]s that are obtained when [insert]ing the [quad] in child states part of the tree
      */
-    abstract fun insert(bitmask: Bitmask, mappings: List<Mapping>)
+    fun insert(quad: Quad): List<Mapping>
 
     /**
-     * Uses this cache to increase the number of satisfied mappings as much as possible, changing the number of mappings.
+     * Returns the result of [join]ing the [mappings] with its own internal state
      */
-    abstract fun List<Pair<Bitmask, List<Mapping>>>.growUsingCache(): List<Pair<Bitmask, List<Mapping>>>
-
-    /**
-     * Returns a sorted version of the provided [patterns], based on characteristics of the join tree implementation
-     */
-    open fun sorted(patterns: Patterns): Patterns = patterns
+    fun join(mappings: List<Mapping>): List<Mapping>
 
     /**
      * Returns a string containing debug information (runtime statistics)
      */
-    open fun debugInfo(): String = " * Join tree statistics unavailable (implementation: ${this::class.simpleName})"
+    fun debugInformation(): String = " * Join tree statistics unavailable (implementation: ${this::class.simpleName})"
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
@@ -25,7 +25,7 @@ internal sealed interface JoinTree {
         override fun insert(quad: Quad): List<Mapping> {
             val new = states
                 .mapIndexed { i, pattern -> Bitmask.onesAt(i, length = states.size) to pattern.insert(quad) }
-                .expandResultSet()
+                .merge()
                 .flatMap { (completed, mappings) -> join(completed, mappings) }
             return new
         }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MutableJoinState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MutableJoinState.kt
@@ -5,9 +5,9 @@ import dev.tesserakt.sparql.runtime.core.Mapping
 
 /**
  * Represents a state type that can be joined with other states of the same (sub-) type, such as triple patterns or
- *  union blocks.
+ *  union blocks, and can process changes to the underlying data being queried.
  */
-interface JoinStateType {
+interface MutableJoinState {
 
     val bindings: Set<String>
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -34,8 +34,8 @@ internal inline fun List<Pair<Bitmask, List<Mapping>>>.merge(): List<Pair<Bitmas
             // if any have been made, its combination can be appended to this result
             if (merged.isNotEmpty()) {
                 result.add(current.first or contender.first to merged)
-                result.removeAt(i)
                 result.removeAt(j)
+                result.removeAt(i)
             } else {
                 ++j
             }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -7,20 +7,21 @@ import dev.tesserakt.sparql.runtime.util.Bitmask
 import dev.tesserakt.util.compatibleWith
 
 /**
- * Adds all results found inside `this` list together where compatible as additional contenders for complete result
- *  generation (for input quads matching multiple patterns at once)
+ * Merges the results found in the receiving collection to a new set of candidate results that guarantee no overlap
  */
-internal inline fun List<Pair<Bitmask, List<Mapping>>>.expandResultSet(): List<Pair<Bitmask, List<Mapping>>> {
+internal inline fun List<Pair<Bitmask, List<Mapping>>>.merge(): List<Pair<Bitmask, List<Mapping>>> {
     // estimating about half of them match for initial capacity
     val result = toMutableList()
     var i = 0
     while (i < result.size - 1) {
         val current = result[i]
-        (i + 1 until result.size).forEach { j ->
+        var j = i + 1
+        while (j < result.size) {
             val contender = result[j]
+            // cannot be already partially applied
             if (!current.first.and(contender.first).isZero()) {
-                // pattern (partially) already applied, no merging should be done
-                return@forEach
+                ++j
+                continue
             }
             // creating all mappings that result from combining these two sub-results
             val merged = current.second.flatMap { mapping ->
@@ -33,6 +34,10 @@ internal inline fun List<Pair<Bitmask, List<Mapping>>>.expandResultSet(): List<P
             // if any have been made, its combination can be appended to this result
             if (merged.isNotEmpty()) {
                 result.add(current.first or contender.first to merged)
+                result.removeAt(i)
+                result.removeAt(j)
+            } else {
+                ++j
             }
         }
         ++i

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.sparql.runtime.common.types.Pattern
@@ -42,16 +40,8 @@ internal inline fun List<Pair<Bitmask, List<Mapping>>>.expandResultSet(): List<P
     return result
 }
 
-internal inline fun doNestedJoin(a: List<Mapping>, b: List<Mapping>) = buildList(a.size + b.size) {
-    a.forEach { left ->
-        b.forEach { right ->
-            if (left.compatibleWith(right)) add(left + right)
-        }
-    }
-}
-
 internal inline fun bindingNamesOf(
     subject: Pattern.Subject,
     predicate: Pattern.Predicate,
     `object`: Pattern.Object
-): List<String> = listOfNotNull(subject.bindingName, predicate.bindingName, `object`.bindingName)
+): Set<String> = setOfNotNull(subject.bindingName, predicate.bindingName, `object`.bindingName)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -34,8 +34,10 @@ internal inline fun List<Pair<Bitmask, List<Mapping>>>.merge(): List<Pair<Bitmas
             // if any have been made, its combination can be appended to this result
             if (merged.isNotEmpty()) {
                 result.add(current.first or contender.first to merged)
-                result.removeAt(j)
-                result.removeAt(i)
+                // removing them like this - it's already possible the current element has been removed from a prior
+                //  iteration with another contender
+                result.remove(current)
+                result.remove(contender)
             } else {
                 ++j
             }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
@@ -12,14 +12,11 @@ internal sealed class SegmentsList {
     }
 
     // the individual already-visited nodes
-    protected val _nodes = mutableSetOf<Quad.Term>()
-    val nodes: Set<Quad.Term> get() = _nodes
+    protected val nodes = mutableSetOf<Quad.Term>()
     // segments connecting the nodes from above
-    protected val _segments = mutableSetOf<Segment>()
-    val segments: Set<Segment> get() = _segments
+    protected val segments = mutableSetOf<Segment>()
     // all paths that can be formed using the segments from above
-    protected val _paths = mutableSetOf<Segment>()
-    val paths: Set<Segment> get() = _paths
+    protected val paths = mutableSetOf<Segment>()
 
     /**
      * A segment list implementation that accepts "zero-length" segments as valid paths, creating them whenever a
@@ -28,7 +25,7 @@ internal sealed class SegmentsList {
     class ZeroLength: SegmentsList() {
 
         override fun newPathsOnAdding(segment: Segment): Set<Segment> {
-            if (segment in _segments) {
+            if (segment in segments) {
                 // no impact, no new paths could be made
                 return emptySet()
             }
@@ -44,14 +41,14 @@ internal sealed class SegmentsList {
             // adding every in-between path that isn't a "zero-length" path (which can occur in circular graphs)
             left.forEach { start -> right.forEach { end -> if (start != end) result.add(Segment(start = start, end = end)) } }
             // if any of the nodes of the new segment are new, they should be considered as zero length paths of their own
-            if (segment.start !in _nodes) {
+            if (segment.start !in nodes) {
                 result.add(Segment(start = segment.start, end = segment.start))
             }
-            if (segment.end !in _nodes) {
+            if (segment.end !in nodes) {
                 result.add(Segment(start = segment.end, end = segment.end))
             }
             // existing paths can't result in new sub-results
-            return result - _paths
+            return result - paths
         }
 
     }
@@ -63,7 +60,7 @@ internal sealed class SegmentsList {
     class SingleLength: SegmentsList() {
 
         override fun newPathsOnAdding(segment: Segment): Set<Segment> {
-            if (segment in _segments) {
+            if (segment in segments) {
                 // no impact, no new paths could be made
                 return emptySet()
             }
@@ -79,7 +76,7 @@ internal sealed class SegmentsList {
             // adding every in-between path, including those that have start == end, as that is now a valid path
             left.forEach { start -> right.forEach { end -> result.add(Segment(start = start, end = end)) } }
             // existing paths can't result in new sub-results
-            return result - _paths
+            return result - paths
         }
 
     }
@@ -90,12 +87,12 @@ internal sealed class SegmentsList {
      */
     fun insert(segment: Segment) {
         // first calculating & inserting its delta directly from the existing segments
-        _paths.addAll(newPathsOnAdding(segment))
+        paths.addAll(newPathsOnAdding(segment))
         // now the segment can be directly added
-        _segments.add(segment)
+        segments.add(segment)
         // inserting the nodes too
-        _nodes.add(segment.start)
-        _nodes.add(segment.end)
+        nodes.add(segment.start)
+        nodes.add(segment.end)
     }
 
     /**
@@ -105,14 +102,14 @@ internal sealed class SegmentsList {
     abstract fun newPathsOnAdding(segment: Segment): Set<Segment>
 
     fun newReachableStartNodesOnAdding(segment: Segment): Set<Quad.Term> {
-        val before = _paths.map { it.start }.toSet()
-        val after = (_paths + newPathsOnAdding(segment)).map { it.start }.toSet()
+        val before = paths.map { it.start }.toSet()
+        val after = (paths + newPathsOnAdding(segment)).map { it.start }.toSet()
         return after - before
     }
 
     fun newReachableEndNodesOnAdding(segment: Segment): Set<Quad.Term> {
-        val before = _paths.map { it.end }.toSet()
-        val after = (_paths + newPathsOnAdding(segment)).map { it.end }.toSet()
+        val before = paths.map { it.end }.toSet()
+        val after = (paths + newPathsOnAdding(segment)).map { it.end }.toSet()
         return after - before
     }
 
@@ -126,40 +123,42 @@ internal sealed class SegmentsList {
 
     protected fun pathsStartingWithUsingSegments(segment: Segment): List<Quad.Term> {
         val result = directlyConnectedEndTermsOf(start = segment.end)
-            .filter { it != segment.start && it != segment.end }
-            .toMutableList()
+            .filterTo(mutableListOf()) { it != segment.end }
+        // TODO(perf):
+        //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
         var new = result.flatMap { current -> directlyConnectedEndTermsOf(start = current) }
-            .filter { it != segment.start && it != segment.end }
+            .filter { it != segment.end }
         val seen = mutableSetOf<Quad.Term>()
         while (new.isNotEmpty()) {
             result.addAll(new)
             seen.addAll(new)
             new = (new.flatMap { current -> directlyConnectedEndTermsOf(start = current) } - seen)
-                .filter { it != segment.start && it != segment.end }
+                .filter { it != segment.end }
         }
         return result
     }
 
     protected fun pathsEndingWithUsingSegments(segment: Segment): List<Quad.Term> {
         val result = directlyConnectedStartTermsOf(end = segment.start)
-            .filter { it != segment.start && it != segment.end }
-            .toMutableList()
+            .filterTo(mutableListOf()) { it != segment.start }
+        // TODO(perf):
+        //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
         var new = result.flatMap { current -> directlyConnectedStartTermsOf(end = current) }
-            .filter { it != segment.start && it != segment.end }
+            .filter { it != segment.start }
         val seen = mutableSetOf<Quad.Term>()
         while (new.isNotEmpty()) {
             result.addAll(new)
             seen.addAll(new)
             new = (new.flatMap { current -> directlyConnectedStartTermsOf(end = current) } - seen)
-                .filter { it != segment.start && it != segment.end }
+                .filter { it != segment.start }
         }
         return result
     }
 
     private fun directlyConnectedStartTermsOf(end: Quad.Term): List<Quad.Term> =
-        _segments.mapNotNull { segment -> segment.start.takeIf { segment.end == end } }
+        segments.mapNotNull { segment -> segment.start.takeIf { segment.end == end } }
 
     private fun directlyConnectedEndTermsOf(start: Quad.Term): List<Quad.Term> =
-        _segments.mapNotNull { segment -> segment.end.takeIf { segment.start == start } }
+        segments.mapNotNull { segment -> segment.end.takeIf { segment.start == start } }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
@@ -53,8 +53,8 @@ internal class SegmentsList {
         // adding every permutation
         left.forEach { start -> result.add(Segment(start = start, end = segment.end)) }
         right.forEach { end -> result.add(Segment(start = segment.start, end = end)) }
-        // adding every in-between path that isn't a "zero-length" path (which can occur in circular graphs)
-        left.forEach { start -> right.forEach { end -> if (start != end) result.add(Segment(start = start, end = end)) } }
+        // adding every in-between path
+        left.forEach { start -> right.forEach { end -> result.add(Segment(start = start, end = end)) } }
         // existing paths can't result in new sub-results
         return result - _paths
     }
@@ -75,6 +75,14 @@ internal class SegmentsList {
 
     fun isConnected(start: Quad.Term, end: Quad.Term): Boolean =
         _paths.any { it.start == start && it.end == end }
+
+    override fun toString() = buildString {
+        appendLine("SegmentList [")
+        appendLine(" * Nodes: $nodes")
+        appendLine(" * Segments: $segments")
+        appendLine(" * Paths: $paths")
+        append("]")
+    }
 
     /**
      * Returns all points that can be formed by beginning with `start`: segments AB, BC, AD, BD and argument A yield


### PR DESCRIPTION
Refactored the entire insertion process.

Main changes are the introduction of a MutableJoinState interface, implemented by all triple pattern states and union segment states, that is used as the new element type housed inside join tree implementations. This allowed the join tree implementations to be further refactored into "owners" of the state instances they combine, making it possible to construct a tree inside another tree (see Left Deep Join Tree using an inner None type), shifting the insertion logic originally found in basic graph pattern and sequence paths fully to the join tree implementations.

Various internal types have been improved functionally. HashJoinArray can now use less indexes than its content contains, allowing for optimal index choices, exploited by left deep join tree. Join collections are now an interface implemented by the hash array, but also by a standalone collection wrapper, allowing for full nested joins if no indexes are possible/available for a given query.

Compliance has been improved based on the newly added internal comparison tests due to a rework of the repeated path implementation. Tests that are known to fail due to missing implementations have been disabled. Overall, performance has been positively impacted based on the various benchmarks and tests. String representation of various internal (state) types have been improved for easier debugging/benchmarking.