### PR TITLE
MutableStore, incremental events and deletions

### DIFF
--- a/benchmarking/src/commonMain/kotlin/Main.kt
+++ b/benchmarking/src/commonMain/kotlin/Main.kt
@@ -23,10 +23,14 @@ suspend fun run(args: Array<String>) {
             val four = builtinTests()
                 .test(QueryExecutionTest::toIncrementalUpdateTest)
                 .run()
+            val five = builtinTests()
+                .test(QueryExecutionTest::toRandomUpdateTest)
+                .run()
             one.report()
             two.report()
             three.report()
             four.report()
+            five.report()
         }
         2 -> {
             val (dataset, querypath) = args

--- a/benchmarking/src/commonMain/kotlin/Main.kt
+++ b/benchmarking/src/commonMain/kotlin/Main.kt
@@ -1,23 +1,37 @@
 
 import dev.tesserakt.util.printerrln
+import sparql.tests.builtinTests
 import sparql.tests.compareIncrementalBasicGraphPatternOutput
 import sparql.tests.compareIncrementalChainSelectOutput
 import sparql.tests.compareIncrementalStarSelectOutput
+import sparql.types.QueryExecutionTest
+import sparql.types.test
 
 suspend fun run(args: Array<String>) {
     when (args.size) {
         0 -> {
             println("Running built-in tests")
-            val one = compareIncrementalChainSelectOutput(seed = 1).run()
-            val two = compareIncrementalStarSelectOutput(seed = 1).run()
-            val three = compareIncrementalBasicGraphPatternOutput().run()
+            val one = compareIncrementalChainSelectOutput(seed = 1)
+                .test(QueryExecutionTest::toOutputComparisonTest)
+                .run()
+            val two = compareIncrementalStarSelectOutput(seed = 1)
+                .test(QueryExecutionTest::toOutputComparisonTest)
+                .run()
+            val three = builtinTests()
+                .test(QueryExecutionTest::toOutputComparisonTest)
+                .run()
+            val four = builtinTests()
+                .test(QueryExecutionTest::toIncrementalUpdateTest)
+                .run()
             one.report()
             two.report()
             three.report()
+            four.report()
         }
         2 -> {
             val (dataset, querypath) = args
             compareIncrementalBasicGraphPatternOutput(datasetFilepath = dataset, queryFilepath = querypath)
+                .test(QueryExecutionTest::toOutputComparisonTest)
                 .run()
                 .report()
         }

--- a/benchmarking/src/commonMain/kotlin/sparql/Util.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/Util.kt
@@ -1,10 +1,10 @@
 package sparql
 
-import dev.tesserakt.rdf.types.Store
+import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 
 
-expect class ExternalQueryExecution(query: String, data: Store) {
+expect class ExternalQueryExecution(query: String, data: Collection<Quad>) {
 
     suspend fun execute(): List<Bindings>
 

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalFile.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalFile.kt
@@ -1,21 +1,20 @@
 package sparql.tests
 
 import dev.tesserakt.rdf.serialization.Turtle.parseTurtleString
-import dev.tesserakt.testing.testEnv
 import dev.tesserakt.util.printerrln
 import sparql.readFile
-import sparql.types.using
+import sparql.types.tests
 
-fun compareIncrementalBasicGraphPatternOutput(datasetFilepath: String, queryFilepath: String) = testEnv {
+fun compareIncrementalBasicGraphPatternOutput(datasetFilepath: String, queryFilepath: String) = tests {
     val store = readFile(datasetFilepath).getOrElse {
         printerrln("Failed to read triples at `$datasetFilepath`! Caught ${it::class.simpleName}")
         it.printStackTrace()
-        return@testEnv
+        return@tests
     }.parseTurtleString()
     val querySource = readFile(queryFilepath).getOrElse {
         printerrln("Failed to read query at `$queryFilepath`! Caught ${it::class.simpleName}")
         it.printStackTrace()
-        return@testEnv
+        return@tests
     }
     // the various queries in the file are expected to be separated using an additional newline, so creating tests for
     //  every query formatted that way

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalSelect.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalSelect.kt
@@ -4,8 +4,7 @@ import dev.tesserakt.rdf.dsl.RdfContext.Companion.buildStore
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
 import dev.tesserakt.rdf.types.Store
-import dev.tesserakt.testing.testEnv
-import sparql.types.using
+import sparql.types.tests
 import kotlin.random.Random
 import kotlin.time.measureTime
 
@@ -17,7 +16,7 @@ import kotlin.time.measureTime
  *  subjects have to be generated, directly affecting the number of outputted bindings due to overlap: a higher
  *  [entropy] yields closer to [size] / 2 resulting bindings.
  */
-fun compareIncrementalChainSelectOutput(size: Int = 500, depth: Int = 7, entropy: Float = 3f, seed: Int = Random.nextInt()) = testEnv {
+fun compareIncrementalChainSelectOutput(size: Int = 500, depth: Int = 7, entropy: Float = 3f, seed: Int = Random.nextInt()) = tests {
     val store: Store
     val predicates = (0 ..< depth).map { "http://example.org/p_$it".asNamedTerm() }
     val rng = Random(seed)
@@ -58,7 +57,7 @@ fun compareIncrementalChainSelectOutput(size: Int = 500, depth: Int = 7, entropy
  * Generates a random graph with a series of relationships and creates a test with a matching query using that graph.
  * [depth] denotes the number of relationships generated for any given subject (and triple patterns in the query)
  */
-fun compareIncrementalStarSelectOutput(size: Int = 200, depth: Int = 5, entropy: Float = 3f, seed: Int = Random.nextInt()) = testEnv {
+fun compareIncrementalStarSelectOutput(size: Int = 200, depth: Int = 5, entropy: Float = 3f, seed: Int = Random.nextInt()) = tests {
     val store: Store
     val predicates: List<Quad.NamedTerm>
     val rng = Random(seed)

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -220,7 +220,19 @@ fun builtinTests() = tests {
 
     using(fullyConnected) test """
         SELECT * WHERE {
+            <http://example.org/a> (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)* ?b
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
             ?a (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)* ?b
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            <http://example.org/c> (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)* <http://example.org/b>
         }
     """
 

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -7,8 +7,7 @@ import dev.tesserakt.rdf.ontology.Ontology
 import dev.tesserakt.rdf.ontology.RDF
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
-import dev.tesserakt.testing.testEnv
-import sparql.types.using
+import sparql.types.tests
 
 object FOAF: Ontology {
 
@@ -22,7 +21,7 @@ object FOAF: Ontology {
 
 }
 
-fun compareIncrementalBasicGraphPatternOutput() = testEnv {
+fun builtinTests() = tests {
     val small = buildStore {
         val subj = local("s")
         val obj = local("o")

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -220,6 +220,12 @@ fun builtinTests() = tests {
 
     using(fullyConnected) test """
         SELECT * WHERE {
+            ?a ((<http://example.org/p>/<http://example.org/p>)*/<http://example.org/p>)* <http://example.org/b>
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
             <http://example.org/a> (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)* ?b
         }
     """
@@ -263,6 +269,18 @@ fun builtinTests() = tests {
     using(fullyConnected) test """
         SELECT * WHERE {
             ?a (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)+ ?b
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            ?a ((<http://example.org/p>/<http://example.org/p>)+/<http://example.org/p>)* <http://example.org/b>
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            ?a ((<http://example.org/p>/<http://example.org/p>)*/<http://example.org/p>)+ <http://example.org/b>
         }
     """
 

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -214,6 +214,18 @@ fun builtinTests() = tests {
 
     using(fullyConnected) test """
         SELECT * WHERE {
+            ?a (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)* <http://example.org/b>
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            ?a (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)* ?b
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
             <http://example.org/a> <http://example.org/p>+ <http://example.org/b>
         }
     """
@@ -227,6 +239,18 @@ fun builtinTests() = tests {
     using(fullyConnected) test """
         SELECT * WHERE {
             ?a <http://example.org/p>+ ?b
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            ?a (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)+ <http://example.org/b>
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
+            ?a (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)+ ?b
         }
     """
 

--- a/benchmarking/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
@@ -4,7 +4,7 @@ import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Compiler.Default.asSPARQLSelectQuery
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 import dev.tesserakt.sparql.runtime.common.util.Debug
-import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery.Companion.query
+import dev.tesserakt.sparql.runtime.incremental.evaluation.query
 import dev.tesserakt.testing.Test
 import dev.tesserakt.testing.runTest
 import dev.tesserakt.util.toTruncatedString
@@ -65,8 +65,23 @@ data class OutputComparisonTest(
             } else null
         }
 
-        override fun toString(): String {
-            return " * Got ${received.size} binding(s) ($elapsedTime):\n\t${received.toTruncatedString(500)}\n * Expected ${expected.size} binding(s) ($referenceTime):\n\t${expected.toTruncatedString(500)}\n * $debugInformation"
+        override fun toString(): String = buildString {
+            append(" * Got ")
+            append(received.size)
+            append(" binding(s) (")
+            append(elapsedTime)
+            append("):\n\t")
+            append(received.toTruncatedString(500))
+            append("\n * Expected ")
+            append(expected.size)
+            append(" binding(s) (")
+            append(referenceTime)
+            append("):\n\t")
+            append(expected.toTruncatedString(500))
+            if (debugInformation.isNotBlank()) {
+                append("\n * ")
+                append(debugInformation)
+            }
         }
 
         companion object {
@@ -88,43 +103,4 @@ data class OutputComparisonTest(
 
     }
 
-}
-
-/**
- * Returns the diff of the two series of bindings. Ideally, the returned list is empty
- */
-private fun compare(
-    received: List<Bindings>,
-    expected: List<Bindings>,
-    elapsedTime: Duration,
-    referenceTime: Duration,
-    debugInformation: String
-): OutputComparisonTest.Result {
-    val leftOver = received.toMutableList()
-    val missing = mutableListOf<Bindings>()
-    expected.forEach { bindings ->
-        if (!leftOver.removeFirst { it == bindings }) {
-            missing.add(bindings)
-        }
-    }
-    return OutputComparisonTest.Result(
-        received = received,
-        expected = expected,
-        leftOver = leftOver,
-        missing = missing,
-        elapsedTime = elapsedTime,
-        referenceTime = referenceTime,
-        debugInformation = debugInformation
-    )
-}
-
-private inline fun <T> MutableList<T>.removeFirst(predicate: (T) -> Boolean): Boolean {
-    val it = listIterator()
-    while (it.hasNext()) {
-        if (predicate(it.next())) {
-            it.remove()
-            return true
-        }
-    }
-    return false
 }

--- a/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTest.kt
@@ -11,4 +11,6 @@ data class QueryExecutionTest(
 
     fun toIncrementalUpdateTest() = IncrementalUpdateTest(query = query, store = store)
 
+    fun toRandomUpdateTest() = RandomUpdateTest(query = query, store = store)
+
 }

--- a/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTest.kt
@@ -1,0 +1,14 @@
+package sparql.types
+
+import dev.tesserakt.rdf.types.Store
+
+data class QueryExecutionTest(
+    val query: String,
+    val store: Store
+) {
+
+    fun toOutputComparisonTest() = OutputComparisonTest(query = query, store = store)
+
+    fun toIncrementalUpdateTest() = IncrementalUpdateTest(query = query, store = store)
+
+}

--- a/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
@@ -1,0 +1,208 @@
+package sparql.types
+
+import dev.tesserakt.rdf.types.MutableStore
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.rdf.types.Store
+import dev.tesserakt.sparql.Compiler.Default.asSPARQLSelectQuery
+import dev.tesserakt.sparql.runtime.common.types.Bindings
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.evaluation.OngoingQueryEvaluation
+import dev.tesserakt.sparql.runtime.incremental.evaluation.query
+import dev.tesserakt.sparql.runtime.incremental.query.IncrementalSelectQuery
+import dev.tesserakt.testing.Test
+import dev.tesserakt.testing.runTest
+import sparql.ExternalQueryExecution
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.measureTime
+
+data class RandomUpdateTest(
+    val query: String,
+    val store: Store,
+    val seed: Int = 1,
+    val iterations: Int = store.size * 2
+) : Test {
+
+    private val deltas = buildList {
+        // getting all delta's by simulating the changes to a hypothetical input store
+        val temp = MutableStore()
+        val random = Random(seed)
+        repeat(iterations) {
+            // getting the next delta
+            val delta = getNextDelta(current = temp, source = store, random = random)
+            temp.process(delta)
+            add(delta)
+        }
+    }
+
+    override suspend fun test() = runTest {
+        val input = MutableStore()
+        val builder = Result.Builder(query = query.asSPARQLSelectQuery(), store = store, deltas = deltas)
+        suspend fun reference(): Pair<Duration, List<Bindings>> {
+            val external = ExternalQueryExecution(query, input)
+            val results: List<Bindings>
+            val elapsed = measureTime {
+                try {
+                    results = external.execute()
+                } catch (t: Throwable) {
+                    throw RuntimeException("Failed to use external implementation reference: ${t.message}", t)
+                }
+            }
+            return elapsed to results
+        }
+
+        val ongoing: OngoingQueryEvaluation<Bindings>
+        val setupTime = measureTime {
+            ongoing = input.query(query.asSPARQLSelectQuery())
+        }
+        // checking the initial state (no data)
+        builder.add(
+            self = setupTime to ongoing.results,
+            reference = reference()
+        )
+        repeat(iterations) { i ->
+            // and processing it
+            val current: List<Bindings>
+            val elapsedTime = measureTime {
+                input.process(deltas[i])
+                current = ongoing.results
+            }
+            builder.add(
+                self = elapsedTime to current,
+                reference = reference()
+            )
+        }
+        builder.build()
+    }
+
+    override fun toString(): String =
+        "Random update SPARQL output comparison test\n * Query: `${
+            query.replace(Regex("\\s+"), " ").trim()
+        }`\n * Input: store with ${store.size} quad(s)"
+
+    data class Result(
+        val store: Store,
+        val query: IncrementalSelectQuery,
+        val outputs: List<OutputComparisonTest.Result>,
+        val deltas: List<Delta.Data>
+    ) : Test.Result {
+
+        class Builder(
+            private val query: IncrementalSelectQuery,
+            private val store: Store,
+            private val deltas: List<Delta.Data>
+        ) {
+
+            private val list = ArrayList<OutputComparisonTest.Result>(store.size * 2)
+
+            fun add(
+                self: Pair<Duration, List<Bindings>>,
+                reference: Pair<Duration, List<Bindings>>,
+            ) {
+                list.add(
+                    compare(
+                        received = self.second,
+                        elapsedTime = self.first,
+                        expected = reference.second,
+                        referenceTime = reference.first,
+                        debugInformation = ""
+                    )
+                )
+            }
+
+            fun build() = Result(store = store, outputs = list, deltas = deltas, query = query)
+
+        }
+
+        override fun isSuccess(): Boolean = outputs.all { it.isSuccess() }
+
+        override fun exceptionOrNull(): Throwable? {
+            val index = outputs.indexOfFirst { !it.isSuccess() }
+            if (index == -1) {
+                return null
+            }
+            return AssertionError(
+                buildString {
+                    when {
+                        index == 0 -> {
+                            // initial state failed
+                            appendLine("Comparison failed without any data")
+                        }
+
+                        else -> {
+                            // incremental change failed
+                            appendLine("First failure occurred at incremental change #${index + 1}")
+                        }
+                    }
+                    if (index >= 1) {
+                        appendLine("Previous result:\n\t${outputs[index - 1].summary()}")
+                    }
+                    append(outputs[index].exceptionOrNull()?.message ?: "Detailed contents unavailable")
+                    appendLine(" * Complete update sequence")
+                    repeat(index) { i ->
+                        append("     ")
+                        appendLine(deltaSummary(i, deltas[i]))
+                    }
+                    append("  >> ")
+                    appendLine(deltaSummary(index, deltas[index]))
+                    // also replaying the entire store up until this point, so all contents used in the reference
+                    //  query can be displayed
+//                    appendLine(" * Contents:")
+//                    val store = MutableStore().apply {
+//                        repeat(index) { process(deltas[it]) }
+//                    }
+//                    append(store.toString().prependIndent("   "))
+                }
+            )
+        }
+
+        override fun toString(): String {
+            val min = outputs.minOf { it.elapsedTime }
+            val max = outputs.maxOf { it.elapsedTime }
+            val mean = (outputs.sumOf { it.elapsedTime.inWholeNanoseconds } / outputs.size).nanoseconds
+            return buildString {
+                appendLine(" * ${outputs.count { it.isSuccess() }} / ${outputs.size} individual output(s) matched")
+                if (outputs.size > 3) {
+                    appendLine("\t...")
+                    repeat(3) {
+                        val i = outputs[outputs.size - 3 + it]
+                        appendLine("\t${i.summary()}")
+                    }
+                }
+                append(" * Incremental time characteristics\n\tmin: $min, mean: $mean, max: $max")
+            }
+        }
+
+    }
+
+}
+
+// helpers
+private fun OutputComparisonTest.Result.summary() =
+    "${received.size} received, ${expected.size} expected, ${missing.size} missing, ${leftOver.size} superfluous"
+
+private fun getNextDelta(current: Set<Quad>, source: Set<Quad>, random: Random): Delta.Data {
+    require(source.isNotEmpty()) { "Empty input data is not allowed!" }
+    // biasing the type of delta based on the amount of triples currently present compared to the number of triples
+    //  possible: if there aren't any triples currently present, then we guarantee an addition happening now, the
+    //  opposite is also true
+    val isAddition = random.nextFloat() >= (current.size / source.size.toFloat())
+    // based on the type, we sample the next `random` item from what we have or what we can still get
+    return if (isAddition) {
+        val available = source - current
+        Delta.DataAddition(available.random(random))
+    } else {
+        Delta.DataDeletion(current.random(random))
+    }
+}
+
+private fun deltaSummary(index: Int, delta: Delta.Data): String =
+    "#${(index + 1).toString().padEnd(3)} [${if (delta is Delta.DataAddition) '+' else '-'}] ${delta.value}"
+
+private fun MutableStore.process(delta: Delta.Data) {
+    when (delta) {
+        is Delta.DataAddition -> add(delta.value)
+        is Delta.DataDeletion -> remove(delta.value)
+    }
+}

--- a/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
@@ -1,15 +1,66 @@
 package sparql.types
 
 import dev.tesserakt.rdf.types.Store
-import dev.tesserakt.testing.TestEnvironment
+import dev.tesserakt.sparql.runtime.common.types.Bindings
+import dev.tesserakt.testing.Test
+import dev.tesserakt.testing.testEnv
+import kotlin.time.Duration
 
+class TestBuilderEnv {
 
-fun TestEnvironment.using(store: Store) = TestBuilder(environment = this, store = store)
+    val tests = mutableListOf<QueryExecutionTest>()
 
-class TestBuilder(private val environment: TestEnvironment, private val store: Store) {
+    fun using(store: Store) = TestBuilder(environment = this, store = store)
+
+}
+
+class TestBuilder(private val environment: TestBuilderEnv, private val store: Store) {
 
     infix fun test(query: String) {
-        environment.add(OutputComparisonTest(query = query, store = store))
+        environment.tests.add(QueryExecutionTest(query = query, store = store))
     }
 
+}
+
+inline fun tests(block: TestBuilderEnv.() -> Unit) = TestBuilderEnv().apply(block).tests.toList()
+
+inline fun List<QueryExecutionTest>.test(mapper: (QueryExecutionTest) -> Test) = testEnv { forEach { add(mapper(it)) } }
+
+/**
+ * Returns the diff of the two series of bindings. Ideally, the returned list is empty
+ */
+fun compare(
+    received: List<Bindings>,
+    expected: List<Bindings>,
+    elapsedTime: Duration,
+    referenceTime: Duration,
+    debugInformation: String
+): OutputComparisonTest.Result {
+    val leftOver = received.toMutableList()
+    val missing = mutableListOf<Bindings>()
+    expected.forEach { bindings ->
+        if (!leftOver.removeFirst { it == bindings }) {
+            missing.add(bindings)
+        }
+    }
+    return OutputComparisonTest.Result(
+        received = received,
+        expected = expected,
+        leftOver = leftOver,
+        missing = missing,
+        elapsedTime = elapsedTime,
+        referenceTime = referenceTime,
+        debugInformation = debugInformation
+    )
+}
+
+private inline fun <T> MutableList<T>.removeFirst(predicate: (T) -> Boolean): Boolean {
+    val it = listIterator()
+    while (it.hasNext()) {
+        if (predicate(it.next())) {
+            it.remove()
+            return true
+        }
+    }
+    return false
 }

--- a/benchmarking/src/jsMain/kotlin/sparql/Util.kt
+++ b/benchmarking/src/jsMain/kotlin/sparql/Util.kt
@@ -3,14 +3,14 @@ package sparql
 import comunica.comunicaSelectQuery
 import dev.tesserakt.interop.rdfjs.n3.N3Store
 import dev.tesserakt.interop.rdfjs.toN3Store
-import dev.tesserakt.rdf.types.Store
+import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 import kotlin.time.measureTime
 
 
 actual class ExternalQueryExecution actual constructor(
     private val query: String,
-    data: Store
+    data: Collection<Quad>
 ) {
 
     private val store: N3Store

--- a/benchmarking/src/jvmMain/kotlin/sparql/Util.kt
+++ b/benchmarking/src/jvmMain/kotlin/sparql/Util.kt
@@ -3,17 +3,16 @@ package sparql
 import dev.tesserakt.interop.jena.toJenaDataset
 import dev.tesserakt.interop.jena.toTerm
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 import org.apache.jena.query.Dataset
 import org.apache.jena.query.QueryExecutionFactory
-import kotlin.time.measureTime
 import kotlin.io.path.Path
 import kotlin.io.path.readText
+import kotlin.time.measureTime
 
 actual class ExternalQueryExecution actual constructor(
     private val query: String,
-    data: Store
+    data: Collection<Quad>
 ) {
 
     private val store: Dataset

--- a/interop/jena/src/jvmMain/kotlin/dev/tesserakt/interop/jena/Extensions.kt
+++ b/interop/jena/src/jvmMain/kotlin/dev/tesserakt/interop/jena/Extensions.kt
@@ -3,7 +3,6 @@ package dev.tesserakt.interop.jena
 import dev.tesserakt.rdf.ontology.XSD
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
-import dev.tesserakt.rdf.types.Store
 import org.apache.jena.datatypes.RDFDatatype
 import org.apache.jena.datatypes.xsd.XSDDatatype
 import org.apache.jena.graph.*
@@ -11,7 +10,7 @@ import org.apache.jena.query.Dataset
 import org.apache.jena.query.DatasetFactory
 import org.apache.jena.query.ReadWrite
 
-fun Store.toJenaDataset(): Dataset {
+fun Collection<Quad>.toJenaDataset(): Dataset {
     val store = DatasetFactory.createTxnMem()
     store.begin(ReadWrite.WRITE)
     try {

--- a/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
+++ b/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
@@ -3,9 +3,8 @@ package dev.tesserakt.interop.rdfjs
 import dev.tesserakt.interop.rdfjs.n3.*
 import dev.tesserakt.rdf.ontology.XSD
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.rdf.types.Store
 
-fun Store.toN3Store(): N3Store {
+fun Collection<Quad>.toN3Store(): N3Store {
     val result = N3Store()
     result.addAll(map { it.toN3Triple() }.toTypedArray())
     return result

--- a/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/MutableStore.kt
+++ b/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/MutableStore.kt
@@ -4,7 +4,7 @@ package dev.tesserakt.rdf.types
 
 import dev.tesserakt.util.fit
 
-class MutableStore(quads: Collection<Quad> = emptyList()): Collection<Quad> {
+class MutableStore(quads: Collection<Quad> = emptyList()): Set<Quad> {
 
     interface Listener {
         fun onQuadAdded(quad: Quad)

--- a/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/MutableStore.kt
+++ b/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/MutableStore.kt
@@ -36,13 +36,29 @@ class MutableStore(quads: Collection<Quad> = emptyList()): Collection<Quad> {
 
     fun add(quad: Quad) {
         if (quads.add(quad)) {
-            listeners.forEach { it.onQuadAdded(quad) }
+            listeners.forEach {
+                try {
+                    it.onQuadAdded(quad)
+                } catch (e: Throwable) {
+                    // TODO: maybe rollback for local data and other listeners?
+                    // TODO: better exception type, or return a result type?
+                    throw RuntimeException("Failed to add `$quad`", e)
+                }
+            }
         }
     }
 
     fun remove(quad: Quad) {
         if (quads.remove(quad)) {
-            listeners.forEach { it.onQuadRemoved(quad) }
+            listeners.forEach {
+                try {
+                    it.onQuadRemoved(quad)
+                } catch (e: Throwable) {
+                    // TODO: maybe rollback for local data and other listeners?
+                    // TODO: better exception type, or return a result type?
+                    throw RuntimeException("Failed to remove `$quad`", e)
+                }
+            }
         }
     }
 
@@ -54,7 +70,7 @@ class MutableStore(quads: Collection<Quad> = emptyList()): Collection<Quad> {
         listeners.remove(listener)
     }
 
-    override fun toString() = buildString {
+    override fun toString() = if (isEmpty()) "Empty store" else buildString {
         val s = quads.map { it.s.toString() }
         val p = quads.map { it.p.toString() }
         val o = quads.map { it.o.toString() }

--- a/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/Store.kt
+++ b/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/Store.kt
@@ -6,7 +6,7 @@ import dev.tesserakt.util.fit
 
 // TODO: make fully immutable
 
-class Store: Collection<Quad> {
+class Store: Set<Quad> {
 
     // TODO: actually performant implementation
     // stored quads utilize set semantics, duplicates are not allowed

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/types/Pattern.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/types/Pattern.kt
@@ -17,6 +17,11 @@ data class Pattern(
     sealed interface Object : CommonNode
 
     /**
+     * Subset of predicates: those that can function (peek functionality) w/o maintaining state
+     */
+    sealed interface StatelessPredicate: Predicate
+
+    /**
      * Subset of predicates: those that are guaranteed to not contain any bindings
      */
     sealed interface UnboundPredicate : Predicate
@@ -48,18 +53,18 @@ data class Pattern(
     }
 
     @JvmInline
-    value class Exact(val term: Quad.Term) : Subject, UnboundPredicate, Object {
+    value class Exact(val term: Quad.Term) : Subject, UnboundPredicate, StatelessPredicate, Object {
         override fun toString() = term.toString()
     }
 
     // FIXME: inverse can either be the inverse of a term (this case) AS WELL AS the inverse of a path (^iri)
     @JvmInline
-    value class Negated(val term: Quad.Term) : UnboundPredicate {
+    value class Negated(val term: Quad.Term) : UnboundPredicate, StatelessPredicate {
         override fun toString() = "!($term)"
     }
 
     @JvmInline
-    value class Alts(val allowed: List<Predicate>) : Predicate {
+    value class Alts(val allowed: List<UnboundPredicate>) : UnboundPredicate {
         override fun toString() = allowed.joinToString(
             separator = " | ",
             prefix = "(",
@@ -69,7 +74,7 @@ data class Pattern(
     }
 
     @JvmInline
-    value class UnboundAlts(val allowed: List<UnboundPredicate>) : UnboundPredicate {
+    value class SimpleAlts(val allowed: List<StatelessPredicate>) : UnboundPredicate, StatelessPredicate {
         override fun toString() = allowed.joinToString(
             separator = " | ",
             prefix = "(",

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/core/pattern/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/core/pattern/Util.kt
@@ -31,7 +31,7 @@ internal fun Pattern.Predicate.matches(term: Quad.Term): Boolean = when (this) {
     is Pattern.GeneratedBinding -> true
     /* all of these match only a subset of terms, so checking manually */
     is Pattern.Exact -> term == this.term
-    is Pattern.UnboundAlts -> allowed.any { it.matches(term) }
+    is Pattern.SimpleAlts -> allowed.any { it.matches(term) }
     is Pattern.Negated -> term != this.term
     /* these cannot be directly matched to terms, so bailing */
     is Pattern.Sequence,

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
@@ -76,6 +76,7 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         //  have to be removed; then a dedicated rebalance method can fill multiple slots at once (avoiding an unnecessarily
         //  large backing collection)
         val pos = backing.indexOfLast { it == mapping }
+        require(pos != -1) { "$mapping cannot be removed from HashJoinArray - not found!" }
         backing.removeAt(pos)
         // the indexes of this mapping have to be removed
         index.forEach { index ->

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
@@ -43,7 +43,8 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         val pos = backing.size
         backing.add(mapping)
         index.forEach { index ->
-            val value = mapping[index.key]!!
+            val value = mapping[index.key]
+                ?: throw IllegalArgumentException("Mapping $mapping has no value required for index `${index.key}`")
             index.value
                 .getOrPut(value) { arrayListOf() }
                 .add(pos)
@@ -61,7 +62,8 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         backing.addAll(mappings)
         mappings.forEachIndexed { i, mapping ->
             index.forEach { index ->
-                val value = mapping[index.key]!!
+                val value = mapping[index.key]
+                    ?: throw IllegalArgumentException("Mapping $mapping has no value required for index `${index.key}`")
                 index.value
                     .getOrPut(value) { arrayListOf() }
                     .add(start + i)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
@@ -69,7 +69,16 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         }
     }
 
+    override fun join(mapping: Mapping): List<Mapping> {
+        val compatible = getCompatibleMappings(mapping)
+        return compatible.mapNotNull { if (it.compatibleWith(mapping)) it + mapping else null }
+    }
+
     override fun join(mappings: List<Mapping>): List<Mapping> {
+        when (mappings.size) {
+            0 -> return emptyList()
+            1 -> return join(mappings.first())
+        }
         val compatible = getCompatibleMappings(mappings)
         return compatible.indices.flatMap { i ->
             compatible[i].mapNotNull { if (it.compatibleWith(mappings[i])) it + mappings[i] else null }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
@@ -8,6 +8,8 @@ interface JoinCollection {
 
     fun join(other: JoinCollection): List<Mapping>
 
+    fun join(mapping: Mapping): List<Mapping>
+
     fun join(mappings: List<Mapping>): List<Mapping>
 
     fun add(mapping: Mapping)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
@@ -16,4 +16,8 @@ interface JoinCollection {
 
     fun addAll(mappings: Collection<Mapping>)
 
+    fun remove(mapping: Mapping)
+
+    fun removeAll(mappings: Collection<Mapping>)
+
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
@@ -19,6 +19,16 @@ internal value class NestedJoinArray(
         }
     }
 
+    override fun join(mapping: Mapping): List<Mapping> {
+        return buildList(mappings.size) {
+            mappings.forEach { contender ->
+                if (contender.compatibleWith(mapping)) {
+                    add(contender + mapping)
+                }
+            }
+        }
+    }
+
     override fun join(mappings: List<Mapping>): List<Mapping> {
         return doNestedJoin(a = this.mappings, b = mappings)
     }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
@@ -41,6 +41,14 @@ internal value class NestedJoinArray(
         this.mappings.addAll(mappings)
     }
 
+    override fun remove(mapping: Mapping) {
+        this.mappings.remove(mapping)
+    }
+
+    override fun removeAll(mappings: Collection<Mapping>) {
+        this.mappings.removeAll(mappings)
+    }
+
     override fun toString() = "NestedJoinArray (cardinality ${mappings.size})"
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
@@ -1,0 +1,29 @@
+package dev.tesserakt.sparql.runtime.incremental.delta
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.core.Mapping
+import kotlin.jvm.JvmInline
+
+sealed interface Delta {
+
+    sealed interface Addition: Delta
+
+    sealed interface Data: Delta {
+        val value: Quad
+    }
+
+    sealed interface Bindings: Delta {
+        val value: Mapping
+    }
+
+    @JvmInline
+    value class DataAddition(override val value: Quad): Addition, Data {
+        override fun toString() = "Additional quad $value"
+    }
+
+    @JvmInline
+    value class BindingsAddition(override val value: Mapping): Addition, Bindings {
+        override fun toString() = "Additional mapping $value"
+    }
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
@@ -8,6 +8,8 @@ sealed interface Delta {
 
     sealed interface Addition: Delta
 
+    sealed interface Deletion: Delta
+
     sealed interface Data: Delta {
         val value: Quad
     }
@@ -18,12 +20,22 @@ sealed interface Delta {
 
     @JvmInline
     value class DataAddition(override val value: Quad): Addition, Data {
-        override fun toString() = "Additional quad $value"
+        override fun toString() = "Adding of quad $value"
     }
 
     @JvmInline
     value class BindingsAddition(override val value: Mapping): Addition, Bindings {
         override fun toString() = "Additional mapping $value"
+    }
+
+    @JvmInline
+    value class DataDeletion(override val value: Quad): Deletion, Data {
+        override fun toString() = "Removal of quad $value"
+    }
+
+    @JvmInline
+    value class BindingsDeletion(override val value: Mapping): Deletion, Bindings {
+        override fun toString() = "Removal of mapping $value"
     }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
@@ -1,0 +1,29 @@
+package dev.tesserakt.sparql.runtime.incremental.delta
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.util.compatibleWith
+
+internal inline fun addition(quad: Quad) = Delta.DataAddition(quad)
+
+internal inline fun addition(mapping: Mapping) = Delta.BindingsAddition(mapping)
+
+operator fun Delta.Bindings.plus(other: Delta.Bindings): Delta.Bindings? {
+    return when {
+        this is Delta.BindingsAddition &&
+        other is Delta.BindingsAddition &&
+        value.compatibleWith(other.value) ->
+            Delta.BindingsAddition(value = value + other.value)
+
+        else -> null
+    }
+}
+
+inline fun Delta.Bindings.map(transform: (Mapping) -> Mapping) = when (this) {
+    is Delta.BindingsAddition -> Delta.BindingsAddition(transform(value))
+}
+
+
+inline fun Delta.Bindings.transform(transform: (Mapping) -> Collection<Mapping>) = when (this) {
+    is Delta.BindingsAddition -> transform(value).map { Delta.BindingsAddition(it) }
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
@@ -21,9 +21,11 @@ operator fun Delta.Bindings.plus(other: Delta.Bindings): Delta.Bindings? {
 
 inline fun Delta.Bindings.map(transform: (Mapping) -> Mapping) = when (this) {
     is Delta.BindingsAddition -> Delta.BindingsAddition(transform(value))
+    is Delta.BindingsDeletion -> Delta.BindingsDeletion(transform(value))
 }
 
 
 inline fun Delta.Bindings.transform(transform: (Mapping) -> Collection<Mapping>) = when (this) {
     is Delta.BindingsAddition -> transform(value).map { Delta.BindingsAddition(it) }
+    is Delta.BindingsDeletion -> transform(value).map { Delta.BindingsDeletion(it) }
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
@@ -24,6 +24,11 @@ class OngoingQueryEvaluation<RT>(private val query: IncrementalQuery<RT, *>) {
         }
     }
 
+    init {
+        // setting the query state as the current results
+        _results.addAll(processor.state())
+    }
+
     fun subscribe(store: MutableStore) {
         store.forEach { quad ->
             processor.process(Delta.DataAddition(quad)).forEach { process(it) }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
@@ -1,0 +1,53 @@
+package dev.tesserakt.sparql.runtime.incremental.evaluation
+
+import dev.tesserakt.rdf.types.MutableStore
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.common.types.Bindings
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery
+
+
+class OngoingQueryEvaluation<RT>(private val query: IncrementalQuery<RT, *>) {
+
+    private val _results = mutableListOf<RT>()
+    val results get() = _results.toList()
+
+    private val processor = query.Processor()
+
+    private val listener = object: MutableStore.Listener {
+        override fun onQuadAdded(quad: Quad) {
+            add(quad)
+        }
+
+        override fun onQuadRemoved(quad: Quad) {
+            remove(quad)
+        }
+    }
+
+    fun subscribe(store: MutableStore) {
+        store.forEach { quad ->
+            processor.process(Delta.DataAddition(quad)).forEach { process(it) }
+        }
+        store.addListener(listener)
+    }
+
+    fun unsubscribe(store: MutableStore) {
+        store.removeListener(listener)
+    }
+
+    fun add(quad: Quad) {
+        processor.process(Delta.DataAddition(quad)).forEach { process(it) }
+    }
+
+    fun remove(quad: Quad) {
+        processor.process(Delta.DataDeletion(quad)).forEach { process(it) }
+    }
+
+    private fun process(change: IncrementalQuery.ResultChange<Bindings>) {
+        when (val mapped = query.process(change)) {
+            is IncrementalQuery.ResultChange.New<*> -> _results.add(mapped.value)
+            is IncrementalQuery.ResultChange.Removed<*> -> _results.remove(mapped.value)
+        }
+    }
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/Query.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/Query.kt
@@ -10,6 +10,11 @@ import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery
 fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>, callback: (IncrementalQuery.ResultChange<RT>) -> Unit) {
     Debug.reset()
     val processor = query.Processor()
+    // setting initial state
+    processor.state().forEach {
+        callback(IncrementalQuery.ResultChange.New(it))
+    }
+    // now incrementally evaluating the input
     val it = iterator()
     while (it.hasNext()) {
         processor.process(Delta.DataAddition(it.next())).forEach {
@@ -23,6 +28,9 @@ fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>, callback: (Increme
 fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>): List<RT> = buildList {
     Debug.reset()
     val processor = query.Processor()
+    // setting initial state
+    addAll(processor.state())
+    // now incrementally evaluating the input
     val it = this@query.iterator()
     while (it.hasNext()) {
         processor.process(Delta.DataAddition(it.next())).forEach {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/Query.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/Query.kt
@@ -1,0 +1,40 @@
+package dev.tesserakt.sparql.runtime.incremental.evaluation
+
+import dev.tesserakt.rdf.types.MutableStore
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.common.util.Debug
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery
+
+
+fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>, callback: (IncrementalQuery.ResultChange<RT>) -> Unit) {
+    Debug.reset()
+    val processor = query.Processor()
+    val it = iterator()
+    while (it.hasNext()) {
+        processor.process(Delta.DataAddition(it.next())).forEach {
+            val mapped = query.process(it)
+            callback(mapped)
+        }
+    }
+    Debug.append(processor.debugInformation())
+}
+
+fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>): List<RT> = buildList {
+    Debug.reset()
+    val processor = query.Processor()
+    val it = this@query.iterator()
+    while (it.hasNext()) {
+        processor.process(Delta.DataAddition(it.next())).forEach {
+            when (val mapped = query.process(it)) {
+                is IncrementalQuery.ResultChange.New<RT> -> add(mapped.value)
+                is IncrementalQuery.ResultChange.Removed<RT> -> remove(mapped.value)
+            }
+        }
+    }
+    Debug.append(processor.debugInformation())
+}
+
+fun <RT> MutableStore.query(query: IncrementalQuery<RT, *>): OngoingQueryEvaluation<RT> {
+    return OngoingQueryEvaluation(query).also { it.subscribe(this) }
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
@@ -1,10 +1,7 @@
 package dev.tesserakt.sparql.runtime.incremental.query
 
-import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.types.Bindings
-import dev.tesserakt.sparql.runtime.common.util.Debug
 import dev.tesserakt.sparql.runtime.incremental.delta.Delta
-import dev.tesserakt.sparql.runtime.incremental.delta.addition
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery.ResultChange.Companion.into
 import dev.tesserakt.sparql.runtime.incremental.state.IncrementalBasicGraphPatternState
 import dev.tesserakt.sparql.runtime.incremental.types.Query
@@ -14,96 +11,36 @@ sealed class IncrementalQuery<ResultType, Q: Query>(
     protected val ast: Q
 ) {
 
-    companion object {
-
-        fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>, callback: (RT) -> Unit) {
-            Debug.reset()
-            val processor = with(query) { Processor(this@query) }
-            var bindings = processor.next()
-            while (bindings != null) {
-                callback(query.process(bindings))
-                bindings = processor.next()
-            }
-            Debug.append(processor.debugInformation())
-        }
-
-        fun <RT> Sequence<Quad>.query(query: IncrementalQuery<RT, *>): Sequence<RT> = sequence {
-            Debug.reset()
-            val processor = with(query) { Processor(this@query.iterator()) }
-            var bindings = processor.next()
-            while (bindings != null) {
-                yield(query.process(bindings))
-                bindings = processor.next()
-            }
-            Debug.append(processor.debugInformation())
-        }
-
-        fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>): List<RT> = buildList {
-            Debug.reset()
-            val processor = with(query) { Processor(this@query) }
-            var bindings = processor.next()
-            while (bindings != null) {
-                add(query.process(bindings))
-                bindings = processor.next()
-            }
-            Debug.append(processor.debugInformation())
-        }
-
-    }
-
-    protected inner class Processor(
-        private val iterator: Iterator<Quad>
-    ) {
-
-        constructor(source: Iterable<Quad>): this(iterator = source.iterator())
+    internal inner class Processor {
 
         private val state = IncrementalBasicGraphPatternState(ast = ast.body)
-        // pending results that have been yielded since last `iterator.next` call, but not yet
-        //  processed through `next()`
-        private val pending = ArrayList<ResultChange>(10)
 
-        fun next(): ResultChange? {
-            if (pending.isNotEmpty()) {
-                return pending.removeFirst()
-            }
-            while (iterator.hasNext()) {
-                val triple = iterator.next()
-                val results = state.insert(addition(triple))
-                return when (results.size) {
-                    // continuing looping
-                    0 -> continue
-                    // only one result, so yielding that and leaving the pending list alone
-                    1 -> results.first().into()
-                    // yielding the first one, adding all other ones to pending
-                    else -> results.first().into().also {
-                        for (r in 1 ..< results.size) { pending.add(results[r].into()) }
-                    }
-                }
-            }
-            return null
+        fun process(data: Delta.Data): List<ResultChange<Bindings>> {
+            return state.insert(data).map { it.into() }
         }
 
         fun debugInformation() = state.debugInformation()
 
     }
 
-    sealed interface ResultChange {
+    sealed interface ResultChange<T> {
 
-        val bindings: Bindings
+        val value: T
 
         @JvmInline
-        value class New(override val bindings: Bindings): ResultChange
+        value class New<T>(override val value: T): ResultChange<T>
         @JvmInline
-        value class Removed(override val bindings: Bindings): ResultChange
+        value class Removed<T>(override val value: T): ResultChange<T>
 
         companion object {
             fun Delta.Bindings.into() = when (this) {
                 is Delta.BindingsAddition -> New(value)
+                is Delta.BindingsDeletion -> Removed(value)
             }
         }
 
     }
 
-    protected abstract fun process(change: ResultChange): ResultType
+    abstract fun process(change: ResultChange<Bindings>): ResultChange<ResultType>
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
@@ -7,10 +7,10 @@ class IncrementalSelectQuery internal constructor(ast: SelectQuery): Incremental
 
     val variables = ast.output.mapTo(mutableSetOf()) { it.name }.toSet()
 
-    override fun process(change: ResultChange): Bindings {
+    override fun process(change: ResultChange<Bindings>): ResultChange<Bindings> {
         return when (change) {
-            is ResultChange.New -> change.bindings.filterKeys { name -> name in variables }
-            is ResultChange.Removed -> TODO()
+            is ResultChange.New -> ResultChange.New(change.value.filterKeys { name -> name in variables })
+            is ResultChange.Removed -> ResultChange.Removed(change.value.filterKeys { name -> name in variables })
         }
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
@@ -7,8 +7,11 @@ class IncrementalSelectQuery internal constructor(ast: SelectQuery): Incremental
 
     val variables = ast.output.mapTo(mutableSetOf()) { it.name }.toSet()
 
-    override fun process(bindings: Bindings): Bindings {
-        return bindings.filterKeys { name -> name in variables }
+    override fun process(change: ResultChange): Bindings {
+        return when (change) {
+            is ResultChange.New -> change.bindings.filterKeys { name -> name in variables }
+            is ResultChange.Removed -> TODO()
+        }
     }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -1,7 +1,6 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
-import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
 import dev.tesserakt.sparql.runtime.incremental.types.Query
 import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
 
@@ -16,25 +15,25 @@ internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
      */
     val bindings: Set<String> = ast.getAllNamedBindings().map { it.name }.toSet()
 
-    fun insert(quad: Quad): List<Mapping> {
-        val total = delta(quad)
-        process(quad)
+    fun insert(delta: Delta.Data): List<Delta.Bindings> {
+        val total = peek(delta)
+        process(delta)
         return total
     }
 
-    fun delta(quad: Quad): List<Mapping> {
-        val first = patterns.delta(quad)
-        val second = unions.delta(quad)
+    fun peek(delta: Delta.Data): List<Delta.Bindings> {
+        val first = patterns.peek(delta)
+        val second = unions.peek(delta)
         return patterns.join(second) + unions.join(first)
     }
 
-    fun process(quad: Quad) {
-        patterns.process(quad)
-        unions.process(quad)
+    fun process(delta: Delta.Data) {
+        patterns.process(delta)
+        unions.process(delta)
     }
 
-    fun join(mappings: List<Mapping>): List<Mapping> {
-        return patterns.join(mappings)
+    fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+        return patterns.join(delta)
     }
 
     fun debugInformation() = buildString {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -33,7 +33,7 @@ internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
     }
 
     fun join(delta: Delta.Bindings): List<Delta.Bindings> {
-        return patterns.join(delta)
+        return unions.join(patterns.join(delta))
     }
 
     fun debugInformation() = buildString {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -1,17 +1,24 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
+import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.types.Pattern
+import dev.tesserakt.sparql.runtime.common.util.getTermOrNull
 import dev.tesserakt.sparql.runtime.core.Mapping
 import dev.tesserakt.sparql.runtime.core.emptyMapping
 import dev.tesserakt.sparql.runtime.core.mappingOf
+import dev.tesserakt.sparql.runtime.core.pattern.matches
 import dev.tesserakt.sparql.runtime.incremental.collection.mutableJoinCollection
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.state.IncrementalTriplePatternState.Companion.createIncrementalPatternState
 import dev.tesserakt.sparql.runtime.incremental.types.SegmentsList
+import kotlin.jvm.JvmInline
 
 internal sealed class IncrementalPathState {
 
     class ZeroOrMoreBinding(
         val start: Pattern.Binding,
-        val end: Pattern.Binding
+        val end: Pattern.Binding,
+        val state: PredicateStateHelper<SegmentsList.ZeroLength.SegmentResult>
     ) : IncrementalPathState() {
 
         private val segments = SegmentsList.ZeroLength()
@@ -19,16 +26,20 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = peek(segment)
-            segments.insert(segment)
-            arr.addAll(delta)
+            arr.addAll(peek(quad))
+            state.peek(quad).forEach { segment -> segments.insert(segment) }
+            state.process(quad)
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
-            return segments.newPathsOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
+        override fun peek(quad: Quad): List<Mapping> {
+            // as it's possible for multiple segments to be returned from a single quad insertion, and this in turn
+            //  cause some paths to come back in duplicates, we make it instantly distinct
+            return state.peek(quad).flatMapTo(mutableSetOf()) { segment ->
+                segments.newPathsOnAdding(segment)
+                    .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
+            }.toList()
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -41,7 +52,8 @@ internal sealed class IncrementalPathState {
 
     class ZeroOrMoreBindingExact(
         val start: Pattern.Binding,
-        val end: Pattern.Exact
+        val end: Pattern.Exact,
+        val state: PredicateStateHelper<SegmentsList.ZeroLength.SegmentResult>
     ) : IncrementalPathState() {
 
         private val segments = SegmentsList.ZeroLength()
@@ -49,16 +61,18 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = peek(segment)
-            segments.insert(segment)
-            arr.addAll(delta)
+            arr.addAll(peek(quad))
+            state.peek(quad).forEach { segments.insert(it) }
+            state.process(quad)
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
-            return segments.newReachableStartNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(start.name to it) }
+        override fun peek(quad: Quad): List<Mapping> {
+            return state.peek(quad).flatMap { segment ->
+                segments.newReachableStartNodesOnAdding(segment)
+                    .mapTo(ArrayList()) { mappingOf(start.name to it) }
+            }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -69,7 +83,8 @@ internal sealed class IncrementalPathState {
 
     class ZeroOrMoreExactBinding(
         val start: Pattern.Exact,
-        val end: Pattern.Binding
+        val end: Pattern.Binding,
+        val state: PredicateStateHelper<SegmentsList.ZeroLength.SegmentResult>
     ) : IncrementalPathState() {
 
         private val segments = SegmentsList.ZeroLength()
@@ -77,16 +92,18 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = peek(segment)
-            segments.insert(segment)
-            arr.addAll(delta)
+            arr.addAll(peek(quad))
+            state.peek(quad).forEach { segments.insert(it) }
+            state.process(quad)
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
-            return segments.newReachableEndNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(end.name to it) }
+        override fun peek(quad: Quad): List<Mapping> {
+            return state.peek(quad).flatMap { segment ->
+                segments.newReachableEndNodesOnAdding(segment)
+                    .mapTo(ArrayList()) { mappingOf(end.name to it) }
+            }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -97,21 +114,26 @@ internal sealed class IncrementalPathState {
 
     class ZeroOrMoreExact(
         val start: Pattern.Exact,
-        val end: Pattern.Exact
+        val end: Pattern.Exact,
+        val predicate: Pattern.ZeroOrMore
     ) : IncrementalPathState() {
 
         private var satisfied = false
 
         override val cardinality: Int get() = if (satisfied) 1 else 0
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
+            if (!predicate.element.matches(quad.p)) {
+                return
+            }
             satisfied = true
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(quad: Quad): List<Mapping> {
             // it's expected that a call to `process` will happen soon after,
             //  so not changing it here
-            return if (!satisfied) {
+            // FIXME is just checking predicates here sufficient?
+            return if (!satisfied && predicate.element.matches(quad.p)) {
                 listOf(emptyMapping())
             } else {
                 emptyList()
@@ -126,7 +148,8 @@ internal sealed class IncrementalPathState {
 
     class OneOrMoreBinding(
         val start: Pattern.Binding,
-        val end: Pattern.Binding
+        val end: Pattern.Binding,
+        val state: PredicateStateHelper<SegmentsList.Segment>
     ) : IncrementalPathState() {
 
         private val segments = SegmentsList.SingleLength()
@@ -134,16 +157,20 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = peek(segment)
-            segments.insert(segment)
-            arr.addAll(delta)
+            arr.addAll(peek(quad))
+            state.peek(quad).forEach { segment -> segments.insert(segment) }
+            state.process(quad)
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
-            return segments.newPathsOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
+        override fun peek(quad: Quad): List<Mapping> {
+            // as it's possible for multiple segments to be returned from a single quad insertion, and this in turn
+            //  cause some paths to come back in duplicates, we make it instantly distinct
+            return state.peek(quad).flatMapTo(mutableSetOf()) { segment ->
+                segments.newPathsOnAdding(segment)
+                    .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
+            }.toList()
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -156,7 +183,8 @@ internal sealed class IncrementalPathState {
 
     class OneOrMoreBindingExact(
         val start: Pattern.Binding,
-        val end: Pattern.Exact
+        val end: Pattern.Exact,
+        val state: PredicateStateHelper<SegmentsList.Segment>
     ) : IncrementalPathState() {
 
         private val segments = SegmentsList.SingleLength()
@@ -164,16 +192,18 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = peek(segment)
-            segments.insert(segment)
-            arr.addAll(delta)
+            arr.addAll(peek(quad))
+            state.peek(quad).forEach { segment -> segments.insert(segment) }
+            state.process(quad)
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
-            return segments.newReachableStartNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(start.name to it) }
+        override fun peek(quad: Quad): List<Mapping> {
+            return state.peek(quad).flatMap { segment ->
+                segments.newReachableStartNodesOnAdding(segment)
+                    .mapTo(ArrayList()) { mappingOf(start.name to it) }
+            }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -184,7 +214,8 @@ internal sealed class IncrementalPathState {
 
     class OneOrMoreExactBinding(
         val start: Pattern.Exact,
-        val end: Pattern.Binding
+        val end: Pattern.Binding,
+        val state: PredicateStateHelper<SegmentsList.Segment>
     ) : IncrementalPathState() {
 
         private val segments = SegmentsList.SingleLength()
@@ -192,16 +223,18 @@ internal sealed class IncrementalPathState {
 
         override val cardinality: Int get() = arr.mappings.size
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = peek(segment)
-            segments.insert(segment)
-            arr.addAll(delta)
+            arr.addAll(peek(quad))
+            state.peek(quad).forEach { segment -> segments.insert(segment) }
+            state.process(quad)
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
-            return segments.newReachableEndNodesOnAdding(segment)
-                .mapTo(ArrayList()) { mappingOf(end.name to it) }
+        override fun peek(quad: Quad): List<Mapping> {
+            return state.peek(quad).flatMap { segment ->
+                segments.newReachableEndNodesOnAdding(segment)
+                    .mapTo(ArrayList()) { mappingOf(end.name to it) }
+            }
         }
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -212,21 +245,26 @@ internal sealed class IncrementalPathState {
 
     class OneOrMoreExact(
         val start: Pattern.Exact,
-        val end: Pattern.Exact
+        val end: Pattern.Exact,
+        val predicate: Pattern.OneOrMore
     ) : IncrementalPathState() {
 
         private var satisfied = false
 
         override val cardinality: Int get() = if (satisfied) 1 else 0
 
-        override fun process(segment: SegmentsList.Segment) {
+        override fun process(quad: Quad) {
+            if (!predicate.element.matches(quad.p)) {
+                return
+            }
             satisfied = true
         }
 
-        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(quad: Quad): List<Mapping> {
             // it's expected that a call to `process` will happen soon after,
             //  so not changing it here
-            return if (!satisfied) {
+            // FIXME is just testing predicate sufficient?
+            return if (!satisfied && predicate.element.matches(quad.p)) {
                 listOf(emptyMapping())
             } else {
                 emptyList()
@@ -239,11 +277,158 @@ internal sealed class IncrementalPathState {
 
     }
 
+    interface PredicateStateHelper<T : SegmentsList.SegmentHolder> {
+
+        class StatelessSegments(
+            override val s: Pattern.Subject,
+            private val p: Pattern.Predicate,
+            override val o: Pattern.Object
+        ) : PredicateStateHelper<SegmentsList.Segment> {
+            override fun peek(quad: Quad): List<SegmentsList.Segment> {
+                return if (p.matches(quad.p)) {
+                    listOf(SegmentsList.Segment(start = quad.s, end = quad.o))
+                } else {
+                    emptyList()
+                }
+            }
+
+            override fun process(quad: Quad) {
+                // NOP -- stateless
+            }
+        }
+
+        class StatelessSegmentResults(
+            private val start: Pattern.Subject,
+            private val p: Pattern.Predicate,
+            private val end: Pattern.Object
+        ) : PredicateStateHelper<SegmentsList.ZeroLength.SegmentResult> {
+
+            override val s: Pattern.Subject
+                get() = start
+
+            override val o: Pattern.Object
+                get() = end
+
+            override fun peek(quad: Quad): List<SegmentsList.ZeroLength.SegmentResult> {
+                return if (p.matches(quad.p)) {
+                    listOf(
+                        SegmentsList.ZeroLength.SegmentResult(
+                            segment = SegmentsList.Segment(start = quad.s, end = quad.o),
+                            isFullMatch = start.matches(quad.s) && end.matches(quad.o)
+                        )
+                    )
+                } else {
+                    emptyList()
+                }
+            }
+
+            override fun process(quad: Quad) {
+                // NOP -- stateless
+            }
+
+        }
+
+        @JvmInline
+        value class StatefulSegments(
+            private val state: IncrementalTriplePatternState<*>
+        ) : PredicateStateHelper<SegmentsList.Segment> {
+
+            override val s: Pattern.Subject
+                get() = state.s
+
+            override val o: Pattern.Object
+                get() = state.o
+
+            override fun peek(quad: Quad): List<SegmentsList.Segment> {
+                val new = state.peek(Delta.DataAddition(quad))
+                val segments = new.map {
+                    SegmentsList.Segment(
+                        start = state.s.getTermOrNull(it)!!,
+                        end = state.o.getTermOrNull(it)!!
+                    )
+                }
+                return segments
+            }
+
+            override fun process(quad: Quad) {
+                state.process(Delta.DataAddition(quad))
+            }
+        }
+
+        @JvmInline
+        value class StatefulSegmentResults(
+            private val state: IncrementalTriplePatternState<*>
+        ) : PredicateStateHelper<SegmentsList.ZeroLength.SegmentResult> {
+
+            override val s: Pattern.Subject
+                get() = state.s
+
+            override val o: Pattern.Object
+                get() = state.o
+
+            override fun peek(quad: Quad): List<SegmentsList.ZeroLength.SegmentResult> {
+                val new = state.peek(Delta.DataAddition(quad))
+                val segments = new.map {
+                    SegmentsList.Segment(
+                        start = state.s.getTermOrNull(it)!!,
+                        end = state.o.getTermOrNull(it)!!
+                    )
+                }
+                // not sure how to evaluate this, so saying it's a full match
+                return segments.map { SegmentsList.ZeroLength.SegmentResult(segment = it, isFullMatch = true) }
+            }
+
+            override fun process(quad: Quad) {
+                state.process(Delta.DataAddition(quad))
+            }
+        }
+
+        val s: Pattern.Subject
+        val o: Pattern.Object
+
+        fun peek(quad: Quad): List<T>
+
+        /**
+         * Inserts this quad if the predicate is not actually stateless
+         */
+        fun process(quad: Quad)
+
+        companion object {
+
+            fun forSegmentResults(
+                start: Pattern.Subject,
+                predicate: Pattern.RepeatingPredicate,
+                end: Pattern.Object
+            ) = when {
+                predicate.element is Pattern.StatelessPredicate ->
+                    StatelessSegmentResults(start, predicate.element, end)
+
+                else -> StatefulSegmentResults(
+                    Pattern(start, predicate.element, end).createIncrementalPatternState()
+                )
+            }
+
+            fun forSegments(
+                start: Pattern.Subject,
+                predicate: Pattern.RepeatingPredicate,
+                end: Pattern.Object
+            ) = when {
+                predicate.element is Pattern.StatelessPredicate ->
+                    StatelessSegments(start, predicate.element, end)
+
+                else ->
+                    StatefulSegments(Pattern(start, predicate.element, end).createIncrementalPatternState())
+            }
+
+        }
+
+    }
+
     abstract val cardinality: Int
 
-    abstract fun process(segment: SegmentsList.Segment)
+    abstract fun process(quad: Quad)
 
-    abstract fun peek(segment: SegmentsList.Segment): List<Mapping>
+    abstract fun peek(quad: Quad): List<Mapping>
 
     abstract fun join(mappings: List<Mapping>): List<Mapping>
 
@@ -251,23 +436,65 @@ internal sealed class IncrementalPathState {
 
         fun zeroOrMore(
             start: Pattern.Subject,
+            predicate: Pattern.RepeatingPredicate,
             end: Pattern.Object
         ) = when {
-            start is Pattern.Exact && end is Pattern.Exact -> ZeroOrMoreExact(start, end)
-            start is Pattern.Binding && end is Pattern.Binding -> ZeroOrMoreBinding(start, end)
-            start is Pattern.Exact && end is Pattern.Binding -> ZeroOrMoreExactBinding(start, end)
-            start is Pattern.Binding && end is Pattern.Exact -> ZeroOrMoreBindingExact(start, end)
+            start is Pattern.Exact && end is Pattern.Exact ->
+                ZeroOrMoreExact(start = start, end = end, predicate = predicate as Pattern.ZeroOrMore)
+
+            start is Pattern.Binding && end is Pattern.Binding ->
+                ZeroOrMoreBinding(
+                    start = start,
+                    end = end,
+                    state = PredicateStateHelper.forSegmentResults(start, predicate, end)
+                )
+
+            start is Pattern.Exact && end is Pattern.Binding ->
+                ZeroOrMoreExactBinding(
+                    start = start,
+                    end = end,
+                    state = PredicateStateHelper.forSegmentResults(start, predicate, end)
+                )
+
+            start is Pattern.Binding && end is Pattern.Exact ->
+                ZeroOrMoreBindingExact(
+                    start = start,
+                    end = end,
+                    state = PredicateStateHelper.forSegmentResults(start, predicate, end)
+                )
+
             else -> throw IllegalStateException("Unknown subject / pattern combination for `ZeroOrMore` predicate construct: $start -> $end")
         }
 
         fun oneOrMore(
             start: Pattern.Subject,
+            predicate: Pattern.RepeatingPredicate,
             end: Pattern.Object
         ) = when {
-            start is Pattern.Exact && end is Pattern.Exact -> OneOrMoreExact(start, end)
-            start is Pattern.Binding && end is Pattern.Binding -> OneOrMoreBinding(start, end)
-            start is Pattern.Exact && end is Pattern.Binding -> OneOrMoreExactBinding(start, end)
-            start is Pattern.Binding && end is Pattern.Exact -> OneOrMoreBindingExact(start, end)
+            start is Pattern.Exact && end is Pattern.Exact ->
+                OneOrMoreExact(start = start, end = end, predicate = predicate as Pattern.OneOrMore)
+
+            start is Pattern.Binding && end is Pattern.Binding ->
+                OneOrMoreBinding(
+                    start = start,
+                    end = end,
+                    state = PredicateStateHelper.forSegments(start, predicate, end)
+                )
+
+            start is Pattern.Exact && end is Pattern.Binding ->
+                OneOrMoreExactBinding(
+                    start = start,
+                    end = end,
+                    state = PredicateStateHelper.forSegments(start, predicate, end)
+                )
+
+            start is Pattern.Binding && end is Pattern.Exact ->
+                OneOrMoreBindingExact(
+                    start = start,
+                    end = end,
+                    state = PredicateStateHelper.forSegments(start, predicate, end)
+                )
+
             else -> throw IllegalStateException("Unknown subject / pattern combination for `OneOrMore` predicate construct: $start -> $end")
         }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -21,12 +21,12 @@ internal sealed class IncrementalPathState {
 
         override fun process(segment: SegmentsList.Segment) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = delta(segment)
+            val delta = peek(segment)
             segments.insert(segment)
             arr.addAll(delta)
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             return segments.newPathsOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
         }
@@ -51,12 +51,12 @@ internal sealed class IncrementalPathState {
 
         override fun process(segment: SegmentsList.Segment) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = delta(segment)
+            val delta = peek(segment)
             segments.insert(segment)
             arr.addAll(delta)
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             return segments.newReachableStartNodesOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(start.name to it) }
         }
@@ -79,12 +79,12 @@ internal sealed class IncrementalPathState {
 
         override fun process(segment: SegmentsList.Segment) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = delta(segment)
+            val delta = peek(segment)
             segments.insert(segment)
             arr.addAll(delta)
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             return segments.newReachableEndNodesOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(end.name to it) }
         }
@@ -108,7 +108,7 @@ internal sealed class IncrementalPathState {
             satisfied = true
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             // it's expected that a call to `process` will happen soon after,
             //  so not changing it here
             return if (!satisfied) {
@@ -136,12 +136,12 @@ internal sealed class IncrementalPathState {
 
         override fun process(segment: SegmentsList.Segment) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = delta(segment)
+            val delta = peek(segment)
             segments.insert(segment)
             arr.addAll(delta)
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             return segments.newPathsOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(start.name to it.start, end.name to it.end) }
         }
@@ -166,12 +166,12 @@ internal sealed class IncrementalPathState {
 
         override fun process(segment: SegmentsList.Segment) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = delta(segment)
+            val delta = peek(segment)
             segments.insert(segment)
             arr.addAll(delta)
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             return segments.newReachableStartNodesOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(start.name to it) }
         }
@@ -194,12 +194,12 @@ internal sealed class IncrementalPathState {
 
         override fun process(segment: SegmentsList.Segment) {
             // TODO(perf): this delta's the segments list twice, can be optimised
-            val delta = delta(segment)
+            val delta = peek(segment)
             segments.insert(segment)
             arr.addAll(delta)
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             return segments.newReachableEndNodesOnAdding(segment)
                 .mapTo(ArrayList()) { mappingOf(end.name to it) }
         }
@@ -223,7 +223,7 @@ internal sealed class IncrementalPathState {
             satisfied = true
         }
 
-        override fun delta(segment: SegmentsList.Segment): List<Mapping> {
+        override fun peek(segment: SegmentsList.Segment): List<Mapping> {
             // it's expected that a call to `process` will happen soon after,
             //  so not changing it here
             return if (!satisfied) {
@@ -243,7 +243,7 @@ internal sealed class IncrementalPathState {
 
     abstract fun process(segment: SegmentsList.Segment)
 
-    abstract fun delta(segment: SegmentsList.Segment): List<Mapping>
+    abstract fun peek(segment: SegmentsList.Segment): List<Mapping>
 
     abstract fun join(mappings: List<Mapping>): List<Mapping>
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -7,6 +7,8 @@ import dev.tesserakt.sparql.runtime.core.emptyMapping
 import dev.tesserakt.sparql.runtime.core.mappingOf
 import dev.tesserakt.sparql.runtime.core.pattern.matches
 import dev.tesserakt.sparql.runtime.incremental.collection.mutableJoinCollection
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.state.IncrementalTriplePatternState.Companion.createIncrementalPatternState
 import dev.tesserakt.sparql.runtime.incremental.types.SegmentsList
 
 internal sealed class IncrementalPathState {
@@ -59,6 +61,55 @@ internal sealed class IncrementalPathState {
 
     }
 
+    class ZeroOrMoreStatefulBindings(
+        val start: Pattern.Binding,
+        inner: Pattern.Predicate,
+        val end: Pattern.Binding,
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList()
+        private val arr = mutableJoinCollection(start.name, end.name)
+        private val inner = Pattern(start, inner, end).createIncrementalPatternState()
+
+        override val cardinality: Int get() = arr.mappings.size
+
+        override fun process(quad: Quad) {
+            arr.addAll(peek(quad))
+            inner.process(Delta.DataAddition(quad))
+            segments.insert(getNewSegments(quad))
+            // two bindings, so adding both ends
+            segments.insert(SegmentsList.Segment(quad.s, quad.s))
+            segments.insert(SegmentsList.Segment(quad.o, quad.o))
+        }
+
+        override fun peek(quad: Quad): List<Mapping> {
+            val new = getNewSegments(quad)
+            // as it's possible for multiple segments to be returned from a single quad insertion, and this in turn
+            //  cause some paths to come back in duplicates, we make it instantly distinct
+            val result = mutableSetOf<Mapping>()
+            segments.newPathsOnAdding(new)
+                .mapTo(result) { mappingOf(start.name to it.start, end.name to it.end) }
+            // as we're two bindings zero length, the quad's edges can also be null-length paths
+            segments.newPathsOnAdding(SegmentsList.Segment(quad.s, quad.s))
+                .forEach { result.add(mappingOf(start.name to it.start, end.name to it.end)) }
+            segments.newPathsOnAdding(SegmentsList.Segment(quad.o, quad.o))
+                .forEach { result.add(mappingOf(start.name to it.start, end.name to it.end)) }
+            return result.toList()
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
+        override fun toString() = segments.toString()
+
+        private fun getNewSegments(quad: Quad): Set<SegmentsList.Segment> {
+            return inner.peek(Delta.DataAddition(quad))
+                .mapTo(mutableSetOf()) { SegmentsList.Segment(start = it[start.name]!!, end = it[end.name]!!) }
+        }
+
+    }
+
     class ZeroOrMoreStatelessBindingExact(
         val start: Pattern.Binding,
         val inner: Pattern.StatelessPredicate,
@@ -108,6 +159,62 @@ internal sealed class IncrementalPathState {
 
     }
 
+    class ZeroOrMoreStatefulBindingExact(
+        val start: Pattern.Binding,
+        inner: Pattern.Predicate,
+        val end: Pattern.Exact,
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList()
+        private val arr = mutableJoinCollection(start.name)
+        // "bridge" binding, responsible for keeping the inner predicate's end variable, allowing for more matches that
+        //  in turn can produce additional results only obtainable by combining these additional matches; i.e.
+        //  A -> B and B -> C should yield A -> C, which is only possible if we don't enforce an exact match C
+        private val bridge = createAnonymousBinding()
+        private val inner = Pattern(start, inner, bridge).createIncrementalPatternState()
+
+        override val cardinality: Int get() = arr.mappings.size
+
+        override fun process(quad: Quad) {
+            arr.addAll(peek(quad))
+            inner.process(Delta.DataAddition(quad))
+            segments.insert(getNewSegments(quad))
+            // only the first represents a binding, so adding the end, but only if it matches exactly
+            if (end.matches(quad.o)) {
+                segments.insert(SegmentsList.Segment(quad.o, quad.o))
+            }
+        }
+
+        override fun peek(quad: Quad): List<Mapping> {
+            val new = getNewSegments(quad)
+            // as it's possible for multiple segments to be returned from a single quad insertion, and this in turn
+            //  cause some paths to come back in duplicates, we make it instantly distinct
+            val result = mutableSetOf<Mapping>()
+            segments.newPathsOnAdding(new)
+                .filter { it.end == end.term }
+                .mapTo(result) { mappingOf(start.name to it.start) }
+            // only adding the end as a zero length binding if it matches the end term
+            if (end.matches(quad.o)) {
+                segments.newPathsOnAdding(SegmentsList.Segment(quad.o, quad.o))
+                    .filter { it.end == end.term }
+                    .forEach { result.add(mappingOf(start.name to it.start)) }
+            }
+            return result.toList()
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
+        override fun toString() = segments.toString()
+
+        private fun getNewSegments(quad: Quad): Set<SegmentsList.Segment> {
+            return inner.peek(Delta.DataAddition(quad))
+                .mapTo(mutableSetOf()) { SegmentsList.Segment(start = it[start.name]!!, end = it[bridge.name]!!) }
+        }
+
+    }
+
     class ZeroOrMoreStatelessExactBinding(
         val start: Pattern.Exact,
         val inner: Pattern.StatelessPredicate,
@@ -143,7 +250,7 @@ internal sealed class IncrementalPathState {
                 .mapTo(result) { mappingOf(end.name to it) }
             // only adding the end as a zero length binding if it matches the end term
             if (start.matches(quad.s)) {
-                segments.newReachableEndNodesOnAdding(SegmentsList.Segment(quad.o, quad.o))
+                segments.newReachableEndNodesOnAdding(SegmentsList.Segment(quad.s, quad.s))
                     .forEach { result.add(mappingOf(end.name to it)) }
             }
             return result.toList()
@@ -154,6 +261,62 @@ internal sealed class IncrementalPathState {
         }
 
         override fun toString() = segments.toString()
+
+    }
+
+    class ZeroOrMoreStatefulExactBinding(
+        val start: Pattern.Exact,
+        inner: Pattern.Predicate,
+        val end: Pattern.Binding,
+    ) : IncrementalPathState() {
+
+        private val segments = SegmentsList()
+        private val arr = mutableJoinCollection(end.name)
+        // "bridge" binding, responsible for keeping the inner predicate's end variable, allowing for more matches that
+        //  in turn can produce additional results only obtainable by combining these additional matches; i.e.
+        //  A -> B and B -> C should yield A -> C, which is only possible if we don't enforce an exact match C
+        private val bridge = createAnonymousBinding()
+        private val inner = Pattern(bridge, inner, end).createIncrementalPatternState()
+
+        override val cardinality: Int get() = arr.mappings.size
+
+        override fun process(quad: Quad) {
+            arr.addAll(peek(quad))
+            inner.process(Delta.DataAddition(quad))
+            segments.insert(getNewSegments(quad))
+            // only the last represents a binding, so adding the end, but only if it matches exactly
+            if (start.matches(quad.s)) {
+                segments.insert(SegmentsList.Segment(quad.s, quad.s))
+            }
+        }
+
+        override fun peek(quad: Quad): List<Mapping> {
+            val new = getNewSegments(quad)
+            // as it's possible for multiple segments to be returned from a single quad insertion, and this in turn
+            //  cause some paths to come back in duplicates, we make it instantly distinct
+            val result = mutableSetOf<Mapping>()
+            segments.newPathsOnAdding(new)
+                .filter { it.start == start.term }
+                .mapTo(result) { mappingOf(end.name to it.end) }
+            // only adding the end as a zero length binding if it matches the end term
+            if (start.matches(quad.s)) {
+                segments.newPathsOnAdding(SegmentsList.Segment(quad.s, quad.s))
+                    .filter { it.start == start.term }
+                    .forEach { result.add(mappingOf(end.name to it.end)) }
+            }
+            return result.toList()
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return arr.join(mappings)
+        }
+
+        override fun toString() = segments.toString()
+
+        private fun getNewSegments(quad: Quad): Set<SegmentsList.Segment> {
+            return inner.peek(Delta.DataAddition(quad))
+                .mapTo(mutableSetOf()) { SegmentsList.Segment(start = it[bridge.name]!!, end = it[end.name]!!) }
+        }
 
     }
 
@@ -178,6 +341,44 @@ internal sealed class IncrementalPathState {
             // it's expected that a call to `process` will happen soon after,
             //  so not changing it here
             return if (!satisfied && inner.matches(quad.p)) {
+                listOf(emptyMapping())
+            } else {
+                emptyList()
+            }
+        }
+
+        override fun join(mappings: List<Mapping>): List<Mapping> {
+            return if (satisfied) mappings else emptyList()
+        }
+
+    }
+
+    class ZeroOrMoreStatefulExact(
+        val start: Pattern.Exact,
+        inner: Pattern.Predicate,
+        val end: Pattern.Exact
+    ) : IncrementalPathState() {
+
+        private var satisfied = false
+
+        // "bridge" binding, responsible for keeping the inner predicate's end variable, allowing for more matches that
+        //  in turn can produce additional results only obtainable by combining these additional matches; i.e.
+        //  A -> B and B -> C should yield A -> C, which is only possible if we don't enforce an exact match C
+        private val bridge = createAnonymousBinding()
+        private val inner = Pattern(start, inner, bridge).createIncrementalPatternState()
+        override val cardinality: Int get() = if (satisfied) 1 else 0
+
+        override fun process(quad: Quad) {
+            if (!satisfied) {
+                satisfied = inner.peek(Delta.DataAddition(quad)).any { it[bridge.name]!! == end.term }
+            }
+            inner.process(Delta.DataAddition(quad))
+        }
+
+        override fun peek(quad: Quad): List<Mapping> {
+            // it's expected that a call to `process` will happen soon after,
+            //  so not changing it here
+            return if (!satisfied && inner.peek(Delta.DataAddition(quad)).any { it[bridge.name]!! == end.term }) {
                 listOf(emptyMapping())
             } else {
                 emptyList()
@@ -393,13 +594,37 @@ internal sealed class IncrementalPathState {
                         throw IllegalStateException("Internal error: unknown subject / pattern combination for `ZeroOrMore` predicate construct: $start -> $end")
                 }
 
-                is Pattern.UnboundSequence -> {
-                    // FIXME
-                    throw IllegalStateException("Repeating sequence patterns are currently not supported!\nOffending triple pattern: ${Pattern(start, predicate, end)}")
-                }
+                else -> when {
+                    start is Pattern.Binding && end is Pattern.Binding ->
+                        ZeroOrMoreStatefulBindings(
+                            start = start,
+                            inner = inner,
+                            end = end,
+                        )
 
-                else -> {
-                    throw IllegalStateException("Invalid query: predicate element `${inner}` cannot be used as a repeating (*) element!\nOffending pattern: ${Pattern(start, predicate, end)}")
+                    start is Pattern.Binding && end is Pattern.Exact ->
+                        ZeroOrMoreStatefulBindingExact(
+                            start = start,
+                            inner = inner,
+                            end = end,
+                        )
+
+                    start is Pattern.Exact && end is Pattern.Binding ->
+                        ZeroOrMoreStatefulExactBinding(
+                            start = start,
+                            inner = inner,
+                            end = end,
+                        )
+
+                    start is Pattern.Exact && end is Pattern.Exact ->
+                        ZeroOrMoreStatefulExact(
+                            start = start,
+                            inner = inner,
+                            end = end,
+                        )
+
+                    else ->
+                        throw IllegalStateException("Internal error: unknown subject / pattern combination for `ZeroOrMore` predicate construct: $start -> $end")
                 }
             }
         }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalTriplePatternState.kt
@@ -139,16 +139,15 @@ internal sealed class IncrementalTriplePatternState<P : Pattern.Predicate>(
         override val cardinality: Int get() = state.cardinality
 
         override fun process(delta: Delta.Data) {
-            state.process(delta.value)
+            state.process(delta)
         }
 
         override fun peek(delta: Delta.DataAddition): List<Mapping> {
-            return state.peek(delta.value)
+            return state.peek(delta)
         }
 
         override fun peek(delta: Delta.DataDeletion): List<Mapping> {
-            // TODO()
-            return emptyList()
+            return state.peek(delta)
         }
 
         override fun join(mapping: Mapping): List<Mapping> {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
@@ -1,7 +1,6 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
-import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
 import dev.tesserakt.sparql.runtime.incremental.types.SelectQuerySegment
 import dev.tesserakt.sparql.runtime.incremental.types.StatementsSegment
 import dev.tesserakt.sparql.runtime.incremental.types.Union
@@ -16,16 +15,16 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
             override val bindings: Set<String> get() = state.bindings
 
-            override fun process(quad: Quad) {
-                return state.process(quad)
+            override fun peek(delta: Delta.Data): List<Delta.Bindings> {
+                return state.peek(delta)
             }
 
-            override fun delta(quad: Quad): List<Mapping> {
-                return state.delta(quad)
+            override fun process(delta: Delta.Data) {
+                return state.process(delta)
             }
 
-            override fun join(mappings: List<Mapping>): List<Mapping> {
-                return state.join(mappings)
+            override fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+                return state.join(delta)
             }
 
         }
@@ -34,15 +33,15 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
             override val bindings: Set<String> = parent.query.output.map { it.name }.toSet()
 
-            override fun process(quad: Quad) {
+            override fun peek(delta: Delta.Data): List<Delta.Bindings> {
                 TODO("Not yet implemented")
             }
 
-            override fun delta(quad: Quad): List<Mapping> {
+            override fun process(delta: Delta.Data) {
                 TODO("Not yet implemented")
             }
 
-            override fun join(mappings: List<Mapping>): List<Mapping> {
+            override fun join(delta: Delta.Bindings): List<Delta.Bindings> {
                 TODO("Not yet implemented")
             }
 
@@ -50,11 +49,11 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
         abstract val bindings: Set<String>
 
-        abstract fun delta(quad: Quad): List<Mapping>
+        abstract fun peek(delta: Delta.Data): List<Delta.Bindings>
 
-        abstract fun process(quad: Quad)
+        abstract fun process(delta: Delta.Data)
 
-        abstract fun join(mappings: List<Mapping>): List<Mapping>
+        abstract fun join(delta: Delta.Bindings): List<Delta.Bindings>
 
     }
 
@@ -62,16 +61,16 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
     override val bindings: Set<String> = buildSet { state.forEach { addAll(it.bindings) } }
 
-    override fun process(quad: Quad) {
-        state.forEach { it.process(quad) }
+    override fun process(delta: Delta.Data) {
+        state.forEach { it.process(delta) }
     }
 
-    override fun delta(quad: Quad): List<Mapping> {
-        return state.flatMap { it.delta(quad) }
+    override fun peek(delta: Delta.Data): List<Delta.Bindings> {
+        return state.flatMap { it.peek(delta) }
     }
 
-    override fun join(mappings: List<Mapping>): List<Mapping> {
-        return state.flatMap { s -> s.join(mappings) }
+    override fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+        return state.flatMap { s -> s.join(delta) }
     }
 
     companion object {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
@@ -64,6 +64,17 @@ internal sealed interface JoinTree {
                     }
                     results
                 }
+
+                is Delta.BindingsDeletion -> {
+                    var results: List<Delta.Bindings> = listOf(delta)
+                    completed.inv().forEach { i ->
+                        results = results.flatMap { states[i].join(it) }
+                        if (results.isEmpty()) {
+                            return emptyList()
+                        }
+                    }
+                    results
+                }
             }
         }
 
@@ -192,6 +203,7 @@ internal sealed interface JoinTree {
             bindings.forEach { binding ->
                 when (binding) {
                     is Delta.BindingsAddition -> cache.add(binding.value)
+                    is Delta.BindingsDeletion -> TODO()
                 }
             }
         }
@@ -307,14 +319,14 @@ internal sealed interface JoinTree {
         @JvmName("forPatterns")
         operator fun invoke(patterns: List<Pattern>) = when {
             // TODO also based on binding overlap
-            patterns.size >= 3 -> LeftDeep(patterns)
+//            patterns.size >= 3 -> LeftDeep(patterns)
             else -> None(patterns)
         }
 
         @JvmName("forUnions")
         operator fun invoke(unions: List<Union>) = when {
             // TODO also based on binding overlap
-            unions.size >= 3 -> LeftDeep(unions)
+//            unions.size >= 3 -> LeftDeep(unions)
             else -> None(unions)
         }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MutableJoinState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MutableJoinState.kt
@@ -1,26 +1,26 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
-import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
 
 /**
  * Represents a state type that can be joined with other states of the same (sub-) type, such as triple patterns or
  *  union blocks, and can process changes to the underlying data being queried.
  */
-interface MutableJoinState {
+internal interface MutableJoinState {
 
     val bindings: Set<String>
 
-    fun join(mappings: List<Mapping>): List<Mapping>
+    fun join(delta: Delta.Bindings): List<Delta.Bindings>
 
     /**
-     * Returns the delta the provided [quad] produces upon insertion
+     * Returns the [Delta.Bindings] changes that occur when [process]ing the [delta] in this state, without
+     *  actually modifying it (see [process] for mutating the state)
      */
-    fun delta(quad: Quad): List<Mapping>
+    fun peek(delta: Delta.Data): List<Delta.Bindings>
 
     /**
-     * Processes an insertion of the [quad] to this state type
+     * Updates the internal state according to the [delta] change.
      */
-    fun process(quad: Quad)
+    fun process(delta: Delta.Data)
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -44,3 +44,41 @@ internal inline fun bindingNamesOf(
 internal inline fun JoinTree.join(deltas: List<Delta.Bindings>): List<Delta.Bindings> {
     return deltas.flatMap { delta -> join(delta) }
 }
+
+internal inline fun Pattern.UnboundSequence.unfold(start: Pattern.Subject, end: Pattern.Object): List<Pattern> {
+    require(chain.size >= 2)
+    val result = ArrayList<Pattern>(chain.size)
+    var subj = start
+    (0 until chain.size - 1).forEach { i ->
+        val p = chain[i]
+        val obj = createAnonymousBinding()
+        result.add(Pattern(subj, p, obj))
+        subj = obj.toSubject()
+    }
+    result.add(Pattern(subj, chain.last(), end))
+    return result
+}
+
+internal inline fun Pattern.Sequence.unfold(start: Pattern.Subject, end: Pattern.Object): List<Pattern> {
+    require(chain.size >= 2)
+    val result = ArrayList<Pattern>(chain.size)
+    var subj = start
+    (0 until chain.size - 1).forEach { i ->
+        val p = chain[i]
+        val obj = createAnonymousBinding()
+        result.add(Pattern(subj, p, obj))
+        subj = obj.toSubject()
+    }
+    result.add(Pattern(subj, chain.last(), end))
+    return result
+}
+
+private fun Pattern.Object.toSubject(): Pattern.Subject = when (this) {
+    is Pattern.GeneratedBinding -> this
+    is Pattern.RegularBinding -> this
+    is Pattern.Exact -> this
+}
+
+private var generatedBindingIndex = 0
+
+internal fun createAnonymousBinding() = Pattern.GeneratedBinding(id = generatedBindingIndex++)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -32,6 +32,7 @@ internal inline fun List<Pair<Bitmask, List<Delta.Bindings>>>.expandBindingDelta
         }
         ++i
     }
+    // TODO(perf): simplify the result: [+ {a}, + {b}, - {a}] == [+ {b}]
     return result
 }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/Counter.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/Counter.kt
@@ -1,0 +1,53 @@
+package dev.tesserakt.sparql.runtime.incremental.types
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class Counter<T> private constructor(private val map: MutableMap<T, Int>): Iterable<Map.Entry<T, Int>> {
+
+    constructor(): this(mutableMapOf())
+
+    val current: Set<T> get() = map.keys
+
+    operator fun get(value: T) = map[value] ?: 0
+
+    operator fun contains(value: T) = value in map
+
+    fun increment(value: T, count: Int = 1) {
+        map[value] = this[value] + count
+    }
+
+    fun increment(changes: Map<T, Int>) {
+        changes.forEach { (value, count) -> increment(value, count) }
+    }
+
+    fun decrement(value: T, count: Int = 1) {
+        val current = this[value]
+        when {
+            current <= count -> { map.remove(value) }
+            else -> { map[value] = current - count }
+        }
+    }
+
+    fun decrement(changes: Map<T, Int>) {
+        changes.forEach { (value, count) -> decrement(value, count) }
+    }
+
+    fun clear(value: T) {
+        map.remove(value)
+    }
+
+    override fun iterator(): Iterator<Map.Entry<T, Int>> {
+        return map.iterator()
+    }
+
+    override fun toString(): String {
+        return joinToString(
+            separator = ", ",
+            prefix = "Counter { ",
+            postfix = " }",
+            transform = { (key, count) -> "$key ($count)" }
+        )
+    }
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
@@ -5,39 +5,76 @@ import dev.tesserakt.rdf.types.Quad
 internal class SegmentsList {
 
     data class Segment(
-        val start: Quad.Term,
-        val end: Quad.Term
+        val start: Quad.Term, val end: Quad.Term
     ) {
         override fun toString() = "$start -> $end"
     }
 
-    // segments connecting the nodes from above
-    private val segments = mutableSetOf<Segment>()
+    // segments connecting the nodes from above, count for removal checks
+    private val segments = Counter<Segment>()
+
     // all paths that can be formed using the segments from above
-    private val paths = mutableSetOf<Segment>()
+    private val _paths = mutableSetOf<Segment>()
+    val paths: Set<Segment> get() = _paths
 
     /**
      * Calculates all path variations that can be formed when adding the new `segment` to this segment store,
      *  WITHOUT actually adding it. Uses segments to calculate all new variations.
      */
-    fun newPathsOnAdding(segment: Segment): Set<Segment> {
-        if (segment in segments) {
+    fun newPathsOnAdding(element: Segment): Set<Segment> {
+        if (element in segments) {
             // no impact, no new paths could be made
             return emptySet()
         }
-        val left = pathsEndingWithUsingSegments(segment, source = segments)
-        val right = pathsStartingWithUsingSegments(segment, source = segments)
-        // all results from `before` are now connected with those `after`, with the new segment at least being part
-        //  of the result
-        val result = LinkedHashSet<Segment>((left.size + 1) * (right.size + 1))
-        result.add(segment)
-        // adding every permutation
-        left.forEach { start -> result.add(Segment(start = start, end = segment.end)) }
-        right.forEach { end -> result.add(Segment(start = segment.start, end = end)) }
-        // adding every in-between path, including those that have start == end, as that is now a valid path
-        left.forEach { start -> right.forEach { end -> result.add(Segment(start = start, end = end)) } }
+        val result = connect(element, segments.current)
         // existing paths can't result in new sub-results
-        return result - paths
+        result.removeAll(_paths)
+        return result
+    }
+
+    fun removedPathsOnRemoving(element: Segment): Set<Segment> {
+        if (segments[element] != 1) {
+            // no impact: the segment is either not present at all (no paths could possibly use it), or the
+            //  segment occurs multiple times (so it is not outright removed)
+            return emptySet()
+        }
+        // TODO(perf): this can definitely be improved
+        // getting all available remaining paths without this segment
+        val remaining = remainingPathsOnRemoving(element)
+        // the final result are the currently available paths that aren't available anymore afterwards
+        return _paths - remaining
+    }
+
+    fun removedPathsOnRemoving(elements: Iterable<Segment>): Set<Segment> {
+        // TODO(perf): this can definitely be improved
+        // getting all available remaining paths without this segment
+        val remaining = remainingPathsOnRemoving(elements)
+        // the final result are the currently available paths that aren't available anymore afterwards
+        return _paths - remaining
+    }
+
+    fun remainingPathsOnRemoving(element: Segment): Set<Segment> {
+        if (segments[element] != 1) {
+            // no impact: the segment is either not present at all (no paths could possibly use it), or the
+            //  segment occurs multiple times (so it is not outright removed)
+            return _paths
+        }
+        // TODO(perf): this can definitely be improved
+        // getting all available remaining paths without this segment
+        return combine(segments.current - element)
+    }
+
+    fun remainingPathsOnRemoving(elements: Iterable<Segment>): Set<Segment> {
+        val counts = elements.groupingBy { it }.eachCount()
+        val removed = counts.mapNotNullTo(mutableSetOf()) { (segment, count) ->
+            segment.takeIf { segments[segment] <= count }
+        }
+        if (removed.isEmpty()) {
+            return _paths
+        }
+        // TODO(perf): this can definitely be improved
+        // getting all available remaining paths without the removed segments
+        return combine(segments.current - removed)
     }
 
     /**
@@ -51,7 +88,9 @@ internal class SegmentsList {
             return emptySet()
         }
         val result = mutableSetOf<Segment>()
-        val total = this.segments.toMutableSet().also { it.addAll(s) }
+        val total = this.segments.current
+            // copy
+            .toMutableSet().also { it.addAll(s) }
         s.forEach { segment ->
             total.remove(segment)
             val left = pathsEndingWithUsingSegments(segment, source = total)
@@ -67,100 +106,195 @@ internal class SegmentsList {
             left.forEach { start -> right.forEach { end -> result.add(Segment(start = start, end = end)) } }
         }
         // existing paths can't result in new sub-results
-        return result - paths
+        result.removeAll(_paths)
+        return result
     }
 
     /**
      * Adds the `segment` to the list of segments, allowing it to be used when calculating the delta, and expands
      *  the number of available path variations
      */
-    fun insert(segment: Segment) {
+    fun insert(element: Segment) {
         // first calculating & inserting its delta directly from the existing segments
-        paths.addAll(newPathsOnAdding(segment))
-        // now the segment can be directly added
-        segments.add(segment)
+        _paths.addAll(newPathsOnAdding(element))
+        // now the segment's count can be updated
+        segments.increment(element)
     }
 
     /**
      * Adds the `segment` to the list of segments, allowing it to be used when calculating the delta, and expands
      *  the number of available path variations
      */
-    fun insert(segments: Set<Segment>) {
-        // first calculating & inserting its delta directly from the existing segments
-        paths.addAll(newPathsOnAdding(segments))
-        // now the segment can be directly added
-        this.segments.addAll(segments)
+    fun insert(elements: Iterable<Segment>) {
+        // first calculating & inserting its delta directly from the existing segments; they can be distinct (= set)
+        //  for the new path calculation
+        _paths.addAll(newPathsOnAdding(elements.toSet()))
+        // now the segment can be directly added, based on their # of occurrences
+        segments.increment(elements.groupingBy { it }.eachCount())
     }
 
+    fun remove(element: Segment) {
+        when (val count = segments[element]) {
+            0 -> {
+                // not found, ignoring
+            }
+            1 -> {
+                // directly removing the segment
+                segments.decrement(element)
+                // available paths have changed
+                // TODO(perf): this can definitely be improved
+                // getting all available remaining paths without this segment
+                _paths.clear()
+                _paths.addAll(combine(segments.current))
+            }
+            else -> {
+                // only subtracting one, but available paths haven't altered
+                segments.decrement(element)
+            }
+        }
+    }
+
+    fun remove(elements: Iterable<Segment>) {
+        val counts = elements.groupingBy { it }.eachCount()
+        val removed = counts.mapNotNullTo(mutableSetOf()) { (segment, count) ->
+            segment.takeIf { val total = segments[segment]; total <= count }
+        }
+        // updating all segment information
+        counts.forEach { (element, count) ->
+            segments.decrement(element, count)
+        }
+        if (removed.isEmpty()) {
+            // nothing to remove, paths haven't altered, so not rebuilding
+            return
+        }
+        // rebuilding the path structure as a result
+        // TODO(perf): this can possibly be improved, depending on whether a path rebuild or a remove check is faster
+        // getting all available remaining paths without this segment
+        _paths.clear()
+        _paths.addAll(combine(segments.current))
+    }
+
+    // TODO remove
     fun newReachableStartNodesOnAdding(segment: Segment): Set<Quad.Term> {
-        val before = paths.mapTo(mutableSetOf()) { it.start }
+        val before = _paths.mapTo(mutableSetOf()) { it.start }
         val after = newPathsOnAdding(segment).mapTo(mutableSetOf()) { it.start }
         return after - before
     }
 
+    // TODO remove
     fun newReachableEndNodesOnAdding(segment: Segment): Set<Quad.Term> {
-        val before = paths.mapTo(mutableSetOf()) { it.end }
+        val before = _paths.mapTo(mutableSetOf()) { it.end }
         val after = newPathsOnAdding(segment).mapTo(mutableSetOf()) { it.end }
         return after - before
     }
 
     override fun toString() = buildString {
         appendLine("SegmentList [")
-        appendLine(" * Segments: $segments")
-        appendLine(" * Paths: $paths")
+        appendLine(" * Segments: ${segments.asIterable().joinToString { "<${it.key}>: ${it.value}" }}")
+        appendLine(" * Paths: $_paths")
         append("]")
     }
 
-    private fun pathsStartingWithUsingSegments(
-        segment: Segment,
-        source: Set<Segment>
-    ): List<Quad.Term> {
-        val result = directlyConnectedEndTermsOf(start = segment.end, source = source)
-            .filterTo(mutableListOf()) { it != segment.end }
-        // TODO(perf):
-        //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
-        var new = result.flatMap { current -> directlyConnectedEndTermsOf(start = current, source = source) }
-            .filter { it != segment.end }
-        val seen = mutableSetOf<Quad.Term>()
-        while (new.isNotEmpty()) {
-            result.addAll(new)
-            seen.addAll(new)
-            new = (new.flatMap { current -> directlyConnectedEndTermsOf(start = current, source = source) } - seen)
+    companion object {
+
+        /**
+         * Returns all paths that can be formed when connecting [segment] with the other [available] segments
+         */
+        private fun connect(segment: Segment, available: Set<Segment>): LinkedHashSet<Segment> {
+            if (segment.start == segment.end) {
+                return linkedSetOf()
+            }
+            val left = pathsEndingWithUsingSegments(segment, source = available)
+            val right = pathsStartingWithUsingSegments(segment, source = available)
+            // all results from `before` are now connected with those `after`, with the new segment at least being part
+            //  of the result
+            val result = LinkedHashSet<Segment>((left.size + 1) * (right.size + 1))
+            result.add(segment)
+            // adding every permutation
+            left.forEach { start -> if (start != segment.end) result.add(Segment(start = start, end = segment.end)) }
+            right.forEach { end -> if (end != segment.start) result.add(Segment(start = segment.start, end = end)) }
+            // adding every in-between path, including those that have start == end, as that is now a valid path
+            left.forEach { start -> right.forEach { end -> if (start != end) result.add(Segment(start = start, end = end)) } }
+            return result
+        }
+
+        /**
+         * Returns all paths that can be formed using the provided [segments]
+         *
+         * This is a "stateless" combine operation; doesn't take existing paths into account
+         */
+        private fun combine(segments: Set<Segment>): LinkedHashSet<Segment> {
+            // TODO(perf): this can definitely be improved upon
+            val result = LinkedHashSet<Segment>(segments.size * segments.size)
+            val s = segments.toMutableSet()
+            segments.forEach { segment ->
+                s.remove(segment)
+                result.addAll(connect(segment, s))
+                s.add(segment)
+            }
+            return result
+        }
+
+        private fun pathsStartingWithUsingSegments(
+            segment: Segment, source: Set<Segment>
+        ): Set<Quad.Term> {
+            val result = directlyConnectedEndTermsOf(
+                start = segment.end,
+                source = source
+            ).filterTo(mutableSetOf()) { it != segment.end }
+            // TODO(perf):
+            //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
+            var new = result
+                .flatMap { current -> directlyConnectedEndTermsOf(start = current, source = source) }
                 .filter { it != segment.end }
+            val seen = mutableSetOf(segment.end)
+            while (new.isNotEmpty()) {
+                result.addAll(new)
+                seen.addAll(new)
+                new = (new.flatMap { current ->
+                    directlyConnectedEndTermsOf(
+                        start = current,
+                        source = source
+                    )
+                } - seen).filter { it != segment.end }
+            }
+            return result
         }
-        return result
-    }
 
-    private fun pathsEndingWithUsingSegments(
-        segment: Segment,
-        source: Set<Segment>
-    ): List<Quad.Term> {
-        val result = directlyConnectedStartTermsOf(end = segment.start, source = source)
-            .filterTo(mutableListOf()) { it != segment.start }
-        // TODO(perf):
-        //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
-        var new = result.flatMap { current -> directlyConnectedStartTermsOf(end = current, source = source) }
-            .filter { it != segment.start }
-        val seen = mutableSetOf<Quad.Term>()
-        while (new.isNotEmpty()) {
-            result.addAll(new)
-            seen.addAll(new)
-            new = (new.flatMap { current -> directlyConnectedStartTermsOf(end = current, source = source) } - seen)
+        private fun pathsEndingWithUsingSegments(
+            segment: Segment, source: Set<Segment>
+        ): Set<Quad.Term> {
+            val result = directlyConnectedStartTermsOf(
+                end = segment.start,
+                source = source
+            ).filterTo(mutableSetOf()) { it != segment.start }
+            // TODO(perf):
+            //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
+            var new = result
+                .flatMap { current -> directlyConnectedStartTermsOf(end = current, source = source) }
                 .filter { it != segment.start }
+            val seen = mutableSetOf(segment.start)
+            while (new.isNotEmpty()) {
+                result.addAll(new)
+                seen.addAll(new)
+                new = (new.flatMap { current ->
+                    directlyConnectedStartTermsOf(
+                        end = current,
+                        source = source
+                    )
+                } - seen).filter { it != segment.start }
+            }
+            return result
         }
-        return result
+
+        private fun directlyConnectedStartTermsOf(
+            end: Quad.Term, source: Set<Segment>
+        ): List<Quad.Term> = source.mapNotNull { segment -> segment.start.takeIf { segment.end == end } }
+
+        private fun directlyConnectedEndTermsOf(
+            start: Quad.Term, source: Set<Segment>
+        ): List<Quad.Term> = source.mapNotNull { segment -> segment.end.takeIf { segment.start == start } }
+
     }
-
-    private fun directlyConnectedStartTermsOf(
-        end: Quad.Term,
-        source: Set<Segment>
-    ): List<Quad.Term> =
-        source.mapNotNull { segment -> segment.start.takeIf { segment.end == end } }
-
-    private fun directlyConnectedEndTermsOf(
-        start: Quad.Term,
-        source: Set<Segment>
-    ): List<Quad.Term> =
-        source.mapNotNull { segment -> segment.end.takeIf { segment.start == start } }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
@@ -11,8 +11,6 @@ internal class SegmentsList {
         override fun toString() = "$start -> $end"
     }
 
-    // the individual already-visited nodes
-    private val nodes = mutableSetOf<Quad.Term>()
     // segments connecting the nodes from above
     private val segments = mutableSetOf<Segment>()
     // all paths that can be formed using the segments from above
@@ -27,8 +25,8 @@ internal class SegmentsList {
             // no impact, no new paths could be made
             return emptySet()
         }
-        val left = pathsEndingWithUsingSegments(segment)
-        val right = pathsStartingWithUsingSegments(segment)
+        val left = pathsEndingWithUsingSegments(segment, source = segments)
+        val right = pathsStartingWithUsingSegments(segment, source = segments)
         // all results from `before` are now connected with those `after`, with the new segment at least being part
         //  of the result
         val result = LinkedHashSet<Segment>((left.size + 1) * (right.size + 1))
@@ -43,6 +41,36 @@ internal class SegmentsList {
     }
 
     /**
+     * Calculates all path variations that can be formed when adding the new `segment` to this segment store,
+     *  WITHOUT actually adding it. Uses segments to calculate all new variations.
+     */
+    fun newPathsOnAdding(segments: Set<Segment>): Set<Segment> {
+        val s = segments.filter { it !in this.segments }
+        if (s.isEmpty()) {
+            // no impact, no new paths could be made
+            return emptySet()
+        }
+        val result = mutableSetOf<Segment>()
+        val total = this.segments.toMutableSet().also { it.addAll(s) }
+        s.forEach { segment ->
+            total.remove(segment)
+            val left = pathsEndingWithUsingSegments(segment, source = total)
+            val right = pathsStartingWithUsingSegments(segment, source = total)
+            total.add(segment)
+            // all results from `before` are now connected with those `after`, with the new segment at least being part
+            //  of the result
+            result.add(segment)
+            // adding every permutation
+            left.forEach { start -> result.add(Segment(start = start, end = segment.end)) }
+            right.forEach { end -> result.add(Segment(start = segment.start, end = end)) }
+            // adding every in-between path, including those that have start == end, as that is now a valid path
+            left.forEach { start -> right.forEach { end -> result.add(Segment(start = start, end = end)) } }
+        }
+        // existing paths can't result in new sub-results
+        return result - paths
+    }
+
+    /**
      * Adds the `segment` to the list of segments, allowing it to be used when calculating the delta, and expands
      *  the number of available path variations
      */
@@ -51,9 +79,17 @@ internal class SegmentsList {
         paths.addAll(newPathsOnAdding(segment))
         // now the segment can be directly added
         segments.add(segment)
-        // inserting the nodes too
-        nodes.add(segment.start)
-        nodes.add(segment.end)
+    }
+
+    /**
+     * Adds the `segment` to the list of segments, allowing it to be used when calculating the delta, and expands
+     *  the number of available path variations
+     */
+    fun insert(segments: Set<Segment>) {
+        // first calculating & inserting its delta directly from the existing segments
+        paths.addAll(newPathsOnAdding(segments))
+        // now the segment can be directly added
+        this.segments.addAll(segments)
     }
 
     fun newReachableStartNodesOnAdding(segment: Segment): Set<Quad.Term> {
@@ -70,50 +106,61 @@ internal class SegmentsList {
 
     override fun toString() = buildString {
         appendLine("SegmentList [")
-        appendLine(" * Nodes: $nodes")
         appendLine(" * Segments: $segments")
         appendLine(" * Paths: $paths")
         append("]")
     }
 
-    private fun pathsStartingWithUsingSegments(segment: Segment): List<Quad.Term> {
-        val result = directlyConnectedEndTermsOf(start = segment.end)
+    private fun pathsStartingWithUsingSegments(
+        segment: Segment,
+        source: Set<Segment>
+    ): List<Quad.Term> {
+        val result = directlyConnectedEndTermsOf(start = segment.end, source = source)
             .filterTo(mutableListOf()) { it != segment.end }
         // TODO(perf):
         //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
-        var new = result.flatMap { current -> directlyConnectedEndTermsOf(start = current) }
+        var new = result.flatMap { current -> directlyConnectedEndTermsOf(start = current, source = source) }
             .filter { it != segment.end }
         val seen = mutableSetOf<Quad.Term>()
         while (new.isNotEmpty()) {
             result.addAll(new)
             seen.addAll(new)
-            new = (new.flatMap { current -> directlyConnectedEndTermsOf(start = current) } - seen)
+            new = (new.flatMap { current -> directlyConnectedEndTermsOf(start = current, source = source) } - seen)
                 .filter { it != segment.end }
         }
         return result
     }
 
-    private fun pathsEndingWithUsingSegments(segment: Segment): List<Quad.Term> {
-        val result = directlyConnectedStartTermsOf(end = segment.start)
+    private fun pathsEndingWithUsingSegments(
+        segment: Segment,
+        source: Set<Segment>
+    ): List<Quad.Term> {
+        val result = directlyConnectedStartTermsOf(end = segment.start, source = source)
             .filterTo(mutableListOf()) { it != segment.start }
         // TODO(perf):
         //  juggling between two mutable lists that are flatmapped into with retain methods for optimisation
-        var new = result.flatMap { current -> directlyConnectedStartTermsOf(end = current) }
+        var new = result.flatMap { current -> directlyConnectedStartTermsOf(end = current, source = source) }
             .filter { it != segment.start }
         val seen = mutableSetOf<Quad.Term>()
         while (new.isNotEmpty()) {
             result.addAll(new)
             seen.addAll(new)
-            new = (new.flatMap { current -> directlyConnectedStartTermsOf(end = current) } - seen)
+            new = (new.flatMap { current -> directlyConnectedStartTermsOf(end = current, source = source) } - seen)
                 .filter { it != segment.start }
         }
         return result
     }
 
-    private fun directlyConnectedStartTermsOf(end: Quad.Term): List<Quad.Term> =
-        segments.mapNotNull { segment -> segment.start.takeIf { segment.end == end } }
+    private fun directlyConnectedStartTermsOf(
+        end: Quad.Term,
+        source: Set<Segment>
+    ): List<Quad.Term> =
+        source.mapNotNull { segment -> segment.start.takeIf { segment.end == end } }
 
-    private fun directlyConnectedEndTermsOf(start: Quad.Term): List<Quad.Term> =
-        segments.mapNotNull { segment -> segment.end.takeIf { segment.start == start } }
+    private fun directlyConnectedEndTermsOf(
+        start: Quad.Term,
+        source: Set<Segment>
+    ): List<Quad.Term> =
+        source.mapNotNull { segment -> segment.end.takeIf { segment.start == start } }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/SegmentsList.kt
@@ -2,122 +2,67 @@ package dev.tesserakt.sparql.runtime.incremental.types
 
 import dev.tesserakt.rdf.types.Quad
 
-internal sealed class SegmentsList<T: SegmentsList.SegmentHolder> {
+internal class SegmentsList {
 
     data class Segment(
         val start: Quad.Term,
         val end: Quad.Term
-    ): SegmentHolder {
+    ) {
         override fun toString() = "$start -> $end"
-        override val segment: Segment get() = this
-    }
-
-    interface SegmentHolder {
-        val segment: Segment
     }
 
     // the individual already-visited nodes
-    protected val nodes = mutableSetOf<Quad.Term>()
+    private val nodes = mutableSetOf<Quad.Term>()
     // segments connecting the nodes from above
-    protected val segments = mutableSetOf<Segment>()
+    private val segments = mutableSetOf<Segment>()
     // all paths that can be formed using the segments from above
-    protected val paths = mutableSetOf<Segment>()
+    private val paths = mutableSetOf<Segment>()
 
     /**
-     * A segment list implementation that accepts "zero-length" segments as valid paths, creating them whenever a
-     *  new segment node is added
+     * Calculates all path variations that can be formed when adding the new `segment` to this segment store,
+     *  WITHOUT actually adding it. Uses segments to calculate all new variations.
      */
-    class ZeroLength: SegmentsList<ZeroLength.SegmentResult>() {
-
-        data class SegmentResult(
-            override val segment: Segment,
-            val isFullMatch: Boolean
-        ): SegmentHolder
-
-        override fun newPathsOnAdding(segment: SegmentResult): Set<Segment> {
-            if (segment.segment in segments) {
-                // no impact, no new paths could be made
-                return emptySet()
-            }
-            val left = pathsEndingWithUsingSegments(segment.segment)
-            val right = pathsStartingWithUsingSegments(segment.segment)
-            // all results from `before` are now connected with those `after`, with the new segment at least being part
-            //  of the result
-            val result = LinkedHashSet<Segment>((left.size + 1) * (right.size + 1))
-            result.add(segment.segment)
-            // adding every permutation
-            left.forEach { start -> result.add(Segment(start = start, end = segment.segment.end)) }
-            right.forEach { end -> result.add(Segment(start = segment.segment.start, end = end)) }
-            // adding every in-between path that isn't a "zero-length" path (which can occur in circular graphs)
-            left.forEach { start -> right.forEach { end -> if (start != end) result.add(Segment(start = start, end = end)) } }
-            // if any of the nodes of the new segment are new, they should be considered as zero length paths of their own
-            if (segment.isFullMatch && Segment(start = segment.segment.start, end = segment.segment.start) !in paths) {
-                result.add(Segment(start = segment.segment.start, end = segment.segment.start))
-            }
-            if (segment.isFullMatch && Segment(start = segment.segment.end, end = segment.segment.end) !in paths) {
-                result.add(Segment(start = segment.segment.end, end = segment.segment.end))
-            }
-            // existing paths can't result in new sub-results
-            return result - paths
+    fun newPathsOnAdding(segment: Segment): Set<Segment> {
+        if (segment in segments) {
+            // no impact, no new paths could be made
+            return emptySet()
         }
-
-    }
-
-    /**
-     * A segment list implementation that does not accept "zero-length" segments as valid paths, resulting in nodes
-     *  only considered as connected upon full path connection
-     */
-    class SingleLength: SegmentsList<Segment>() {
-
-        override fun newPathsOnAdding(segment: Segment): Set<Segment> {
-            if (segment in segments) {
-                // no impact, no new paths could be made
-                return emptySet()
-            }
-            val left = pathsEndingWithUsingSegments(segment)
-            val right = pathsStartingWithUsingSegments(segment)
-            // all results from `before` are now connected with those `after`, with the new segment at least being part
-            //  of the result
-            val result = LinkedHashSet<Segment>((left.size + 1) * (right.size + 1))
-            result.add(segment)
-            // adding every permutation
-            left.forEach { start -> result.add(Segment(start = start, end = segment.end)) }
-            right.forEach { end -> result.add(Segment(start = segment.start, end = end)) }
-            // adding every in-between path, including those that have start == end, as that is now a valid path
-            left.forEach { start -> right.forEach { end -> result.add(Segment(start = start, end = end)) } }
-            // existing paths can't result in new sub-results
-            return result - paths
-        }
-
+        val left = pathsEndingWithUsingSegments(segment)
+        val right = pathsStartingWithUsingSegments(segment)
+        // all results from `before` are now connected with those `after`, with the new segment at least being part
+        //  of the result
+        val result = LinkedHashSet<Segment>((left.size + 1) * (right.size + 1))
+        result.add(segment)
+        // adding every permutation
+        left.forEach { start -> result.add(Segment(start = start, end = segment.end)) }
+        right.forEach { end -> result.add(Segment(start = segment.start, end = end)) }
+        // adding every in-between path, including those that have start == end, as that is now a valid path
+        left.forEach { start -> right.forEach { end -> result.add(Segment(start = start, end = end)) } }
+        // existing paths can't result in new sub-results
+        return result - paths
     }
 
     /**
      * Adds the `segment` to the list of segments, allowing it to be used when calculating the delta, and expands
      *  the number of available path variations
      */
-    fun insert(segment: T) {
+    fun insert(segment: Segment) {
         // first calculating & inserting its delta directly from the existing segments
         paths.addAll(newPathsOnAdding(segment))
         // now the segment can be directly added
-        segments.add(segment.segment)
+        segments.add(segment)
         // inserting the nodes too
-        nodes.add(segment.segment.start)
-        nodes.add(segment.segment.end)
+        nodes.add(segment.start)
+        nodes.add(segment.end)
     }
 
-    /**
-     * Calculates all path variations that can be formed when adding the new `segment` to this segment store,
-     *  WITHOUT actually adding it. Uses segments to calculate all new variations.
-     */
-    abstract fun newPathsOnAdding(segment: T): Set<Segment>
-
-    fun newReachableStartNodesOnAdding(segment: T): Set<Quad.Term> {
+    fun newReachableStartNodesOnAdding(segment: Segment): Set<Quad.Term> {
         val before = paths.mapTo(mutableSetOf()) { it.start }
         val after = newPathsOnAdding(segment).mapTo(mutableSetOf()) { it.start }
         return after - before
     }
 
-    fun newReachableEndNodesOnAdding(segment: T): Set<Quad.Term> {
+    fun newReachableEndNodesOnAdding(segment: Segment): Set<Quad.Term> {
         val before = paths.mapTo(mutableSetOf()) { it.end }
         val after = newPathsOnAdding(segment).mapTo(mutableSetOf()) { it.end }
         return after - before
@@ -131,7 +76,7 @@ internal sealed class SegmentsList<T: SegmentsList.SegmentHolder> {
         append("]")
     }
 
-    protected fun pathsStartingWithUsingSegments(segment: Segment): List<Quad.Term> {
+    private fun pathsStartingWithUsingSegments(segment: Segment): List<Quad.Term> {
         val result = directlyConnectedEndTermsOf(start = segment.end)
             .filterTo(mutableListOf()) { it != segment.end }
         // TODO(perf):
@@ -148,7 +93,7 @@ internal sealed class SegmentsList<T: SegmentsList.SegmentHolder> {
         return result
     }
 
-    protected fun pathsEndingWithUsingSegments(segment: Segment): List<Quad.Term> {
+    private fun pathsEndingWithUsingSegments(segment: Segment): List<Quad.Term> {
         val result = directlyConnectedStartTermsOf(end = segment.start)
             .filterTo(mutableListOf()) { it != segment.start }
         // TODO(perf):

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Util.kt
@@ -49,7 +49,7 @@ private fun Pattern.Predicate.getNamedBinding(): Pattern.RegularBinding? = when 
     is Pattern.Exact,
     is Pattern.GeneratedBinding,
     is Pattern.Sequence,
-    is Pattern.UnboundAlts,
+    is Pattern.SimpleAlts,
     is Pattern.UnboundSequence,
     is Pattern.Negated,
     is Pattern.OneOrMore,

--- a/testing/rdf-test-suite-js/src/jsMain/kotlin/Runner.kt
+++ b/testing/rdf-test-suite-js/src/jsMain/kotlin/Runner.kt
@@ -4,7 +4,7 @@ import dev.tesserakt.interop.rdfjs.toQuad
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Compiler
 import dev.tesserakt.sparql.Compiler.Default.asSPARQLSelectQuery
-import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery.Companion.query
+import dev.tesserakt.sparql.runtime.incremental.evaluation.query
 
 // IMPORTANT: this file cannot be part of a package, as otherwise `parse` & `query` are not properly accessible in the
 //  exported module (they live in a matching namespace)


### PR DESCRIPTION
Expands the existing query API by introducing a MutableStore, where ongoing query evaluations can be attached. The MutableStore's contents can be incrementally updated, allowing both additions and removals of quads, which are then propagated to all active listeners (ongoing query evaluations). The existing Store implementation is still mutable from a data side of things, but cannot be used to attach ongoing query evaluations onto.

Most incremental types have been expanded to support deletions, with one notable exception being OneOrMore paths. Furthermore, additional tests have been implemented, and fixes to existing insertion logic and initial state according to the SPARQL spec have been added to fix bugs encountered with these new tests.

Not all test cases pass, but the current implementation is a vast improvement over the existing logic, and the newly offered incremental update API can be considered stable for new features to be built upon.