### PR TITLE
OPTIONAL implementation

### DIFF
--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -58,6 +58,28 @@ fun builtinTests() = tests {
         }
     """
 
+    using(small) test """
+        SELECT * {
+            ?s <http://example.org/path1> ?o
+            OPTIONAL {
+                ?s <http://example.org/path2> ?o2
+            }
+        }        
+    """
+
+    using(small) test """
+        SELECT * {
+            {
+                ?s <http://example.org/path2> ?o
+            } UNION {
+                ?s <http://example.org/path1> ?o            
+            }
+            OPTIONAL {
+                ?o <http://example.org/path1> ?o2
+            }
+        }        
+    """
+
     val extra = buildStore(path = "http://example.org/") {
         val subj = local("s")
         val obj = local("o")
@@ -379,6 +401,15 @@ fun builtinTests() = tests {
         SELECT * WHERE {
             ?person <${FOAF.based_near}>/ex:number ?number ;
                     <${FOAF.based_near}>/ex:street ?street
+        }
+    """
+
+    using(person1) test """
+        PREFIX ex: <https://www.example.org/>
+        SELECT * WHERE {
+            ?person <${FOAF.based_near}> ?location .
+            ?location ex:number ?number .
+            OPTIONAL { ?location ex:street ?street }
         }
     """
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/Util.kt
@@ -11,7 +11,7 @@ internal fun QueryAST.QueryBodyAST.extractAllBindings(): List<PatternAST.Binding
     (
         patterns.flatMap { pattern -> pattern.extractAllBindings() } +
         unions.flatMap { union -> union.flatMap { it.extractAllBindings() } } +
-        optionals.flatMap { optional -> optional.segment.extractAllBindings() }
+        optionals.flatMap { optional -> optional.patterns.flatMap { it.extractAllBindings() } }
     ).distinct()
 
 fun SegmentAST.extractAllBindings() = when (this) {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/analyser/QueryBodyProcessor.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/analyser/QueryBodyProcessor.kt
@@ -33,8 +33,14 @@ class QueryBodyProcessor: Analyser<QueryAST.QueryBodyAST>() {
                 Token.Keyword.Optional -> {
                     // consuming the "OPTIONAL" keyword before extracting the segment
                     consume()
+                    // also consuming its brackets
+                    expectToken(Token.Symbol.CurlyBracketStart)
+                    consume()
                     // extracting the segment and inserting it
-                    builder.addOptional(use(SegmentProcessor()))
+                    builder.addOptional(use(PatternProcessor()))
+                    // now eating the closing syntax
+                    expectToken(Token.Symbol.CurlyBracketEnd)
+                    consume()
                 }
                 Token.Symbol.CurlyBracketStart -> {
                     builder.addUnion(use(UnionProcessor()))

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/ast/QueryAST.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/ast/QueryAST.kt
@@ -14,7 +14,7 @@ sealed class QueryAST: ASTNode {
         private val _filters = mutableListOf<FilterAST>()
         private val _bindingStatements = mutableListOf<ExpressionAST.BindingStatement>()
         // collections of sections not required to be being present (`OPTIONAL {}`)
-        private val _optionals = mutableListOf<SegmentAST>()
+        private val _optionals = mutableListOf<PatternsAST>()
         // collections of multiple segments where one or the other has to be present (`{} UNION {}`)
         private val _unions = mutableListOf<List<SegmentAST>>()
 
@@ -51,7 +51,7 @@ sealed class QueryAST: ASTNode {
         }
 
         /** Appends a new optional to the body **/
-        fun addOptional(optional: SegmentAST) {
+        fun addOptional(optional: PatternsAST) {
             _optionals.add(optional)
         }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/ast/Wrappers.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/ast/Wrappers.kt
@@ -9,7 +9,7 @@ value class PatternsAST(private val items: List<PatternAST>): List<PatternAST> b
 value class UnionAST(val segments: List<SegmentAST>): List<SegmentAST> by segments, ASTNode
 
 @JvmInline
-value class OptionalAST(val segment: SegmentAST): ASTNode
+value class OptionalAST(val patterns: PatternsAST): ASTNode
 
 sealed interface SegmentAST: ASTNode {
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/formatting/ASTWriter.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/formatting/ASTWriter.kt
@@ -170,7 +170,7 @@ class ASTWriter(private val indentStyle: String = "  ") {
 
         is OptionalAST -> {
             append("optional ")
-            process(symbol.segment)
+            process(symbol.patterns)
         }
 
         is PatternAST -> {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/formatting/NodeWriter.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/formatting/NodeWriter.kt
@@ -154,10 +154,10 @@ abstract class NodeWriter<RT> {
             }
 
             is Optional -> {
-                when (symbol.segment) {
-                    is SelectQuerySegment -> { process(symbol.segment) }
-                    is StatementsSegment -> { process(symbol.segment) }
-                }
+                add(Token.Keyword.Optional)
+                add(Token.Symbol.CurlyBracketStart)
+                process(symbol.patterns)
+                add(Token.Symbol.CurlyBracketEnd)
             }
 
             is Union -> {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/compat/DirectPatternCompatLayer.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/compat/DirectPatternCompatLayer.kt
@@ -1,0 +1,171 @@
+package dev.tesserakt.sparql.runtime.incremental.compat
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.compiler.ast.PatternAST
+import dev.tesserakt.sparql.compiler.ast.PatternsAST
+import dev.tesserakt.sparql.runtime.common.types.Pattern
+import dev.tesserakt.sparql.runtime.incremental.types.Patterns
+
+/**
+ * Similar compat layer as the regular [PatternCompatLayer], but with a more direct conversion method where no unions
+ *  are being generated for alt path structures.
+ */
+object DirectPatternCompatLayer : IncrementalCompatLayer<PatternsAST, Patterns>() {
+
+    private var _id = 0
+
+    override fun convert(source: PatternsAST): Patterns {
+        val patterns = mutableListOf<Pattern>()
+        source.forEach { patterns.insert(it) }
+        return Patterns(patterns)
+    }
+
+    private fun MutableList<Pattern>.insert(pattern: PatternAST) {
+        insert(subj = pattern.s, pred = pattern.p, obj = pattern.o)
+    }
+
+    private fun MutableList<Pattern>.insert(
+        subj: PatternAST.Subject,
+        pred: PatternAST.Predicate,
+        obj: PatternAST.Object
+    ) {
+        when (pred) {
+            is PatternAST.Alts -> {
+                add(
+                    element = Pattern(
+                        s = subj.toPatternSubject(),
+                        p = Pattern.Alts(pred.allowed.map { it.toPatternPredicate() as Pattern.UnboundPredicate }),
+                        o = obj.toPatternObject(this)
+                    )
+                )
+            }
+
+            is PatternAST.Chain -> {
+                when (pred.chain.size) {
+                    0 -> throw IllegalStateException("Empty predicate chain is not allowed!")
+                    1 -> insert(subj, pred.chain.single(), obj)
+                    else -> {
+                        var start = subj
+                        var end: PatternAST.Element
+                        (0 until pred.chain.size - 1).forEach { i ->
+                            end = generateBlank().toPatternASTObject()
+                            insert(start, pred.chain[i], end)
+                            start = end
+                        }
+                        insert(start, pred.chain.last(), obj)
+                    }
+                }
+            }
+
+            is PatternAST.Binding -> {
+                add(
+                    element = Pattern(
+                        s = subj.toPatternSubject(),
+                        p = Pattern.RegularBinding(pred.name),
+                        o = obj.toPatternObject(this)
+                    )
+                )
+            }
+
+            is PatternAST.Exact -> {
+                add(
+                    element = Pattern(
+                        s = subj.toPatternSubject(),
+                        p = Pattern.Exact(pred.term),
+                        o = obj.toPatternObject(this)
+                    )
+                )
+            }
+
+            is PatternAST.Not,
+            is PatternAST.ZeroOrMore,
+            is PatternAST.OneOrMore -> {
+                // it's contents can't be further flattened, so inserting it directly
+                add(
+                    element = Pattern(
+                        s = subj.toPatternSubject(),
+                        p = pred.toPatternPredicate(),
+                        o = obj.toPatternObject(this)
+                    )
+                )
+            }
+        }
+    }
+
+    private fun PatternAST.Subject.toPatternSubject(): Pattern.Subject = when (this) {
+        is PatternAST.Binding -> Pattern.RegularBinding(name)
+        is PatternAST.Exact -> Pattern.Exact(term)
+    }
+
+    private fun PatternAST.Object.toPatternObject(
+        context: MutableList<Pattern>
+    ): Pattern.Object = when (this) {
+        is PatternAST.Binding -> Pattern.RegularBinding(name)
+        is PatternAST.Exact -> Pattern.Exact(term)
+        is PatternAST.BlankObject -> {
+            val generated = generateBlank()
+            val subj = generated.toPatternASTObject()
+            properties.forEach {
+                context.insert(
+                    subj = subj,
+                    pred = it.p,
+                    obj = it.o
+                )
+            }
+            generated
+        }
+    }
+
+    private fun PatternAST.Predicate.toPatternPredicate(): Pattern.Predicate = when (this) {
+        is PatternAST.Alts -> {
+            val mapped = allowed.map { it.toPatternPredicate() }
+            if (mapped.all { it is Pattern.StatelessPredicate }) {
+                Pattern.SimpleAlts(mapped.unsafeCast())
+            } else if (mapped.all { it is Pattern.UnboundPredicate }) {
+                Pattern.Alts(mapped.unsafeCast())
+            } else {
+                throw IllegalArgumentException("Invalid combination of predicates found inside of alternate pattern group: $mapped")
+            }
+        }
+
+        is PatternAST.Chain -> {
+            val mapped = chain.map { it.toPatternPredicate() }
+            if (mapped.all { it is Pattern.UnboundPredicate }) {
+                Pattern.UnboundSequence(mapped.unsafeCast())
+            } else {
+                Pattern.Sequence(mapped)
+            }
+        }
+
+        is PatternAST.Exact -> Pattern.Exact(term)
+        is PatternAST.Not -> Pattern.Negated(term = predicate.termOrBail())
+        is PatternAST.OneOrMore -> Pattern.OneOrMore(element = value.toUnboundPatternPredicateOrBail())
+        is PatternAST.ZeroOrMore -> Pattern.ZeroOrMore(element = value.toUnboundPatternPredicateOrBail())
+        is PatternAST.Binding -> Pattern.RegularBinding(name)
+    }
+
+    private fun PatternAST.Predicate.toUnboundPatternPredicateOrBail(): Pattern.UnboundPredicate = when (this) {
+        is PatternAST.Alts -> toPatternPredicate() as Pattern.UnboundPredicate
+        is PatternAST.Chain -> Pattern.UnboundSequence(chain = chain.map { it.toUnboundPatternPredicateOrBail() })
+        is PatternAST.Exact -> Pattern.Exact(term)
+        is PatternAST.Not -> Pattern.Negated(term = predicate.termOrBail())
+        is PatternAST.OneOrMore -> Pattern.OneOrMore(element = value.toUnboundPatternPredicateOrBail())
+        is PatternAST.ZeroOrMore -> Pattern.ZeroOrMore(element = value.toUnboundPatternPredicateOrBail())
+        is PatternAST.Binding -> throw IllegalArgumentException("Invalid predicate usage! Binding `$name` cannot appear here.")
+    }
+
+    private fun generateBlank() = Pattern.GeneratedBinding(id = _id++)
+
+    private fun Pattern.GeneratedBinding.toPatternASTObject() = PatternAST.Binding(name = name)
+
+}
+
+/* helpers */
+
+private inline fun <R> Any.unsafeCast(): R {
+    @Suppress("UNCHECKED_CAST")
+    return this as R
+}
+
+private inline fun PatternAST.Predicate.termOrBail(): Quad.Term =
+    (this as? PatternAST.Exact)?.term ?: throw IllegalArgumentException("IRI predicate expected, got `$this`")

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/compat/QueryBodyCompatLayer.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/compat/QueryBodyCompatLayer.kt
@@ -11,7 +11,8 @@ object QueryBodyCompatLayer: IncrementalCompatLayer<QueryAST.QueryBodyAST, Query
         val unions = source.unions.convert().toMutableList()
         val patterns = PatternCompatLayer { blocks -> unions.add(Union(blocks)) }
             .convert(source.patterns)
-        val optional = source.optionals.map { Optional(it.segment.convert()) }
+        val optional = source.optionals
+            .map { Optional(patterns = DirectPatternCompatLayer.convert(it.patterns)) }
         val filters = source.filters.map { it.convert() }
         val bindingStatements = source.bindingStatements.map { it.convert() }
         return Query.QueryBody(

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -2,12 +2,14 @@ package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.sparql.runtime.incremental.delta.Delta
 import dev.tesserakt.sparql.runtime.incremental.types.Query
+import dev.tesserakt.sparql.runtime.util.Bitmask
 import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
 
 internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
 
-    private val patterns = JoinTree(ast.patterns)
+    private val patterns = IncrementalPatternsState(ast.patterns)
     private val unions = JoinTree(ast.unions)
+    private val optionals = JoinTree(ast, ast.optional)
 
     /**
      * A collection of all bindings found inside this query body; it is not guaranteed that all solutions generated
@@ -22,18 +24,40 @@ internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
     }
 
     fun peek(delta: Delta.Data): List<Delta.Bindings> {
-        val first = patterns.peek(delta)
-        val second = unions.peek(delta)
-        return patterns.join(second) + unions.join(first)
+        // applying peek logic similar to the None join tree type, where overlapping compatibilities are also expanded
+        //  upon before joined with prior data found in the remaining sections of the query body
+        return listOf(
+            Bitmask.onesAt(0, length = 3) to patterns.peek(delta),
+            Bitmask.onesAt(1, length = 3) to unions.peek(delta),
+            Bitmask.onesAt(2, length = 3) to optionals.peek(delta)
+        )
+            .expandBindingDeltas()
+            .flatMap { (completed, delta) ->
+                var result = delta
+                // 0 = patterns in the list
+                if (0 !in completed) {
+                    result = patterns.join(result)
+                }
+                // 1 = unions in the list
+                if (1 !in completed) {
+                    result = unions.join(result)
+                }
+                // 2 = optionals in the list
+                if (2 !in completed) {
+                    result = optionals.join(result)
+                }
+                result
+            }
     }
 
     fun process(delta: Delta.Data) {
         patterns.process(delta)
         unions.process(delta)
+        optionals.process(delta)
     }
 
     fun join(delta: Delta.Bindings): List<Delta.Bindings> {
-        return unions.join(patterns.join(delta))
+        return optionals.join(unions.join(patterns.join(delta)))
     }
 
     fun debugInformation() = buildString {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalOptionalState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalOptionalState.kt
@@ -1,0 +1,64 @@
+package dev.tesserakt.sparql.runtime.incremental.state
+
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.types.Optional
+import dev.tesserakt.sparql.runtime.incremental.types.Query
+import dev.tesserakt.sparql.runtime.util.getAllBindings
+import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
+
+class IncrementalOptionalState(parent: Query.QueryBody, ast: Optional): MutableJoinState {
+
+    private val state = IncrementalPatternsState(ast.patterns)
+
+    override val bindings: Set<String> = ast.patterns
+        .getAllNamedBindings()
+        .mapTo(mutableSetOf()) { it.name }
+
+    // extracting of our own bindings not visible to the parent, required for accurate deltas during `peek()`
+    private val internalBindings: Set<String> = run {
+        val ours = ast.patterns.getAllBindings()
+        val parents = parent.patterns.getAllBindings() + parent.unions.flatMapTo(mutableSetOf()) { it.segments.flatMap { it.getAllBindings() } }
+        (ours - parents).mapTo(mutableSetOf()) { it.name }
+    }
+
+    init {
+        check(internalBindings.isNotEmpty()) {
+            "Invalid optional state! Optionals with no unique bindings have no effect, and should be optimised away!\nProblematic optional: $ast"
+        }
+    }
+
+    override fun peek(delta: Delta.Data): List<Delta.Bindings> {
+        when (delta) {
+            is Delta.DataAddition -> {
+                // with the data change, it's possible we transition from an unsatisfied optional to a satisfied one,
+                //  meaning we have to remove the unsatisfied no-bindings results first with an appropriate deletion call
+                val peeked = state.peek(delta)
+                // duping what we peeked, first requesting them to be removed (non-internal bindings)
+                //  (subset of bindings visible to the parent query body), and then added back
+                val deletions = peeked.map { Delta.BindingsDeletion(it.value - internalBindings) }
+                return deletions + peeked
+            }
+            is Delta.DataDeletion -> {
+                // with the data change, it's possible we transition from a satisfied optional to an unsatisfied one,
+                //  meaning we have to remove the satisfied bindings results first with an appropriate deletion call
+                val peeked = state.peek(delta)
+                // duping what we peeked, first requesting them to be removed (non-internal bindings)
+                //  (subset of bindings visible to the parent query body), and then added back
+                val additions = peeked.map { Delta.BindingsAddition(it.value - internalBindings) }
+                return peeked + additions
+            }
+        }
+    }
+
+    override fun process(delta: Delta.Data) {
+        // simply propagating it downwards
+        state.process(delta)
+    }
+
+    override fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+        // joining as is typical, but propagating the original delta if there's nothing compatible to join with, as
+        //  we're optional here
+        return state.join(delta).ifEmpty { listOf(delta) }
+    }
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPatternsState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPatternsState.kt
@@ -1,0 +1,40 @@
+package dev.tesserakt.sparql.runtime.incremental.state
+
+import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.types.Patterns
+
+class IncrementalPatternsState(ast: Patterns) {
+
+    private val state = JoinTree(ast)
+
+    fun peek(delta: Delta.DataAddition): List<Delta.BindingsAddition> {
+        // we can guarantee it in this case
+        @Suppress("UNCHECKED_CAST")
+        return state.peek(delta) as List<Delta.BindingsAddition>
+    }
+
+    fun peek(delta: Delta.DataDeletion): List<Delta.BindingsDeletion> {
+        // we can guarantee it in this case
+        @Suppress("UNCHECKED_CAST")
+        return state.peek(delta) as List<Delta.BindingsDeletion>
+    }
+
+    fun peek(delta: Delta.Data): List<Delta.Bindings> {
+        return state.peek(delta)
+    }
+
+    fun process(delta: Delta.Data) {
+        return state.process(delta)
+    }
+
+    fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+        return state.join(delta)
+    }
+
+    fun join(delta: List<Delta.Bindings>): List<Delta.Bindings> {
+        return state.join(delta)
+    }
+
+    fun debugInformation() = state.debugInformation()
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/Wrappers.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/types/Wrappers.kt
@@ -12,7 +12,7 @@ value class Patterns(private val items: List<Pattern>): List<Pattern> by items, 
 value class Union(val segments: List<Segment>): List<Segment> by segments, IncrementalNode
 
 @JvmInline
-value class Optional(val segment: Segment): IncrementalNode
+value class Optional(val patterns: Patterns): IncrementalNode
 
 sealed interface Segment
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/util/Util.kt
@@ -6,8 +6,15 @@ import dev.tesserakt.sparql.runtime.incremental.types.*
 fun Query.QueryBody.getAllNamedBindings(): Set<Pattern.RegularBinding> =
     buildSet {
         addAll(patterns.getAllNamedBindings())
-        optional.forEach { optional -> addAll(optional.segment.getAllNamedBindings()) }
+        optional.forEach { optional -> addAll(optional.patterns.getAllNamedBindings()) }
         unions.forEach { union -> union.forEach { segment -> addAll(segment.getAllNamedBindings()) } }
+    }
+
+fun Query.QueryBody.getAllBindings(): Set<Pattern.Binding> =
+    buildSet {
+        addAll(patterns.getAllBindings())
+        optional.forEach { optional -> addAll(optional.patterns.getAllBindings()) }
+        unions.forEach { union -> union.forEach { segment -> addAll(segment.getAllBindings()) } }
     }
 
 /**
@@ -17,6 +24,16 @@ fun Patterns.getAllNamedBindings(): Set<Pattern.RegularBinding> =
     buildSet {
         this@getAllNamedBindings.forEach { pattern ->
             addAll(pattern.getAllNamedBindings())
+        }
+    }
+
+/**
+ * Extracts all bindings from the original query
+ */
+fun Patterns.getAllBindings(): Set<Pattern.Binding> =
+    buildSet {
+        this@getAllBindings.forEach { pattern ->
+            addAll(pattern.getAllBindings())
         }
     }
 
@@ -34,13 +51,37 @@ fun Pattern.getAllNamedBindings(): Set<Pattern.RegularBinding> {
     }
 }
 
-private fun Segment.getAllNamedBindings(): Set<Pattern.RegularBinding> {
+fun Pattern.getAllBindings(): Set<Pattern.Binding> {
+    return if (
+        s !is Pattern.Binding &&
+        p !is Pattern.Binding &&
+        o !is Pattern.Binding
+    ) {
+        emptySet()
+    } else buildSet {
+        (s as? Pattern.Binding)?.let { add(it) }
+        p.getBinding()?.let { add(it) }
+        (o as? Pattern.Binding)?.let { add(it) }
+    }
+}
+
+fun Segment.getAllNamedBindings(): Set<Pattern.RegularBinding> {
     return when (this) {
         is SelectQuerySegment ->
             query.output.map { output -> Pattern.RegularBinding(output.name) }.toSet()
 
         is StatementsSegment ->
             statements.getAllNamedBindings()
+    }
+}
+
+fun Segment.getAllBindings(): Set<Pattern.Binding> {
+    return when (this) {
+        is SelectQuerySegment ->
+            query.output.map { output -> Pattern.RegularBinding(output.name) }.toSet()
+
+        is StatementsSegment ->
+            statements.getAllBindings()
     }
 }
 
@@ -55,4 +96,17 @@ private fun Pattern.Predicate.getNamedBinding(): Pattern.RegularBinding? = when 
     is Pattern.OneOrMore,
     is Pattern.ZeroOrMore -> null
     is Pattern.RegularBinding -> this
+}
+
+
+private fun Pattern.Predicate.getBinding(): Pattern.Binding? = when (this) {
+    is Pattern.Alts,
+    is Pattern.Exact,
+    is Pattern.Sequence,
+    is Pattern.SimpleAlts,
+    is Pattern.UnboundSequence,
+    is Pattern.Negated,
+    is Pattern.OneOrMore,
+    is Pattern.ZeroOrMore -> null
+    is Pattern.Binding -> this
 }


### PR DESCRIPTION
Added OPTIONAL evaluation, propagating proper incremental result updates on incremental data changes, replacing unmatched results with matched results upon becoming available and vice versa. The query compiler is also more spec compliant, now only accepting regular statements in OPTIONAL blocks instead of entire query segments used in UNION blocks.