### PR TITLE
Deletion fixes and performance improvements

### DIFF
--- a/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalReplay.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalReplay.kt
@@ -41,6 +41,8 @@ private data class ReplayTestResult(
 
 }
 
+expect fun awaitBenchmarkStart()
+
 suspend fun compareIncrementalStoreReplay(benchmarkFilepath: String) {
     val benchmark = ReplayBenchmark
         .from(store = TriGSerializer.deserialize(Path(benchmarkFilepath)).consume())
@@ -50,6 +52,7 @@ suspend fun compareIncrementalStoreReplay(benchmarkFilepath: String) {
     } else {
         println("Found ${benchmark.queries.size} queries that will be used on a store with ${benchmark.store.snapshotCount} snapshot(s)!")
     }
+    awaitBenchmarkStart()
     benchmark.queries.forEachIndexed { i, query ->
         val store = MutableStore()
         val evaluation = store.query(query.asSPARQLSelectQuery())

--- a/benchmarking/src/commonMain/kotlin/sparql/types/Comparison.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/Comparison.kt
@@ -1,0 +1,29 @@
+package sparql.types
+
+import dev.tesserakt.sparql.runtime.common.types.Bindings
+import dev.tesserakt.util.replace
+
+
+data class ComparisonResult(
+    val missing: List<Bindings>,
+    val leftOver: List<Bindings>
+)
+
+val ExactMatch = ComparisonResult(emptyList(), emptyList())
+
+fun fastCompare(
+    a: List<Bindings>,
+    b: List<Bindings>
+): ComparisonResult {
+    val counts = a.groupingBy { it }.eachCount().toMutableMap()
+    b.forEach {
+        counts.replace(it) { v -> (v ?: 0) - 1 }
+    }
+    if (counts.all { it.value == 0 }) {
+        return ExactMatch
+    }
+    return ComparisonResult(
+        missing = counts.filter { it.value > 0 }.flatMap { entry -> List(entry.value) { entry.key } },
+        leftOver = counts.filter { it.value < 0 }.flatMap { entry -> List(-entry.value) { entry.key } },
+    )
+}

--- a/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
@@ -5,7 +5,9 @@ import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Compiler.Default.asSPARQLSelectQuery
 import dev.tesserakt.sparql.runtime.common.types.Bindings
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.DataAddition
+import dev.tesserakt.sparql.runtime.incremental.delta.DataDeletion
+import dev.tesserakt.sparql.runtime.incremental.delta.DataDelta
 import dev.tesserakt.sparql.runtime.incremental.evaluation.OngoingQueryEvaluation
 import dev.tesserakt.sparql.runtime.incremental.evaluation.query
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalSelectQuery
@@ -85,13 +87,13 @@ data class RandomUpdateTest(
         val store: Store,
         val query: IncrementalSelectQuery,
         val outputs: List<OutputComparisonTest.Result>,
-        val deltas: List<Delta.Data>
+        val deltas: List<DataDelta>
     ) : Test.Result {
 
         class Builder(
             private val query: IncrementalSelectQuery,
             private val store: Store,
-            private val deltas: List<Delta.Data>
+            private val deltas: List<DataDelta>
         ) {
 
             private val list = ArrayList<OutputComparisonTest.Result>(store.size * 2)
@@ -182,7 +184,7 @@ data class RandomUpdateTest(
 private fun OutputComparisonTest.Result.summary() =
     "${received.size} received, ${expected.size} expected, ${missing.size} missing, ${leftOver.size} superfluous"
 
-private fun getNextDelta(current: Set<Quad>, source: Set<Quad>, random: Random): Delta.Data {
+private fun getNextDelta(current: Set<Quad>, source: Set<Quad>, random: Random): DataDelta {
     require(source.isNotEmpty()) { "Empty input data is not allowed!" }
     // biasing the type of delta based on the amount of triples currently present compared to the number of triples
     //  possible: if there aren't any triples currently present, then we guarantee an addition happening now, the
@@ -191,18 +193,18 @@ private fun getNextDelta(current: Set<Quad>, source: Set<Quad>, random: Random):
     // based on the type, we sample the next `random` item from what we have or what we can still get
     return if (isAddition) {
         val available = source - current
-        Delta.DataAddition(available.random(random))
+        DataAddition(available.random(random))
     } else {
-        Delta.DataDeletion(current.random(random))
+        DataDeletion(current.random(random))
     }
 }
 
-private fun deltaSummary(index: Int, delta: Delta.Data): String =
-    "#${(index + 1).toString().padEnd(3)} [${if (delta is Delta.DataAddition) '+' else '-'}] ${delta.value}"
+private fun deltaSummary(index: Int, delta: DataDelta): String =
+    "#${(index + 1).toString().padEnd(3)} [${if (delta is DataAddition) '+' else '-'}] ${delta.value}"
 
-private fun MutableStore.process(delta: Delta.Data) {
+private fun MutableStore.process(delta: DataDelta) {
     when (delta) {
-        is Delta.DataAddition -> add(delta.value)
-        is Delta.DataDeletion -> remove(delta.value)
+        is DataAddition -> add(delta.value)
+        is DataDeletion -> remove(delta.value)
     }
 }

--- a/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
@@ -26,30 +26,6 @@ inline fun tests(block: TestBuilderEnv.() -> Unit) = TestBuilderEnv().apply(bloc
 
 inline fun List<QueryExecutionTest>.test(mapper: (QueryExecutionTest) -> Test) = testEnv { forEach { add(mapper(it)) } }
 
-private data class ComparisonResult(
-    val missing: List<Bindings>,
-    val leftOver: List<Bindings>
-)
-
-private val ExactMatch = ComparisonResult(emptyList(), emptyList())
-
-private fun fastCompare(
-    a: List<Bindings>,
-    b: List<Bindings>
-): ComparisonResult {
-    val counts = a.groupingBy { it }.eachCount().toMutableMap()
-    b.forEach {
-        counts[it] = (counts[it] ?: 0) - 1
-    }
-    if (counts.all { it.value == 0 }) {
-        return ExactMatch
-    }
-    return ComparisonResult(
-        missing = counts.filter { it.value > 0 }.flatMap { entry -> List(entry.value) { entry.key } },
-        leftOver = counts.filter { it.value < 0 }.flatMap { entry -> List(-entry.value) { entry.key } },
-    )
-}
-
 /**
  * Returns the diff of the two series of bindings. Ideally, the returned list is empty
  */

--- a/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
@@ -36,7 +36,7 @@ fun compare(
     referenceTime: Duration,
     debugInformation: String
 ): OutputComparisonTest.Result {
-    val comparison = fastCompare(received, expected)
+    val comparison = fastCompare(expected, received)
     return OutputComparisonTest.Result(
         received = received,
         expected = expected,

--- a/benchmarking/src/jsMain/kotlin/sparql/tests/IncrementalReplay.js.kt
+++ b/benchmarking/src/jsMain/kotlin/sparql/tests/IncrementalReplay.js.kt
@@ -1,0 +1,5 @@
+package sparql.tests
+
+actual fun awaitBenchmarkStart() {
+    // not awaiting anything
+}

--- a/benchmarking/src/jvmMain/kotlin/sparql/tests/IncrementalReplay.jvm.kt
+++ b/benchmarking/src/jvmMain/kotlin/sparql/tests/IncrementalReplay.jvm.kt
@@ -1,0 +1,7 @@
+package sparql.tests
+
+actual fun awaitBenchmarkStart() {
+    println("PID: ${ProcessHandle.current().pid()}")
+    println("Benchmark ready. Press enter to start")
+    System.`in`.read()
+}

--- a/common/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
+++ b/common/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
@@ -102,3 +102,8 @@ inline fun <T> MutableList<T>.weightedSort(weights: List<Int>) {
 }
 
 inline infix fun IntRange.shifted(shift: Int): IntRange = (first + shift) .. (last + shift)
+
+/**
+ * Replaces the value associated with [key] with the value computed by [transform]ing the original value (if any)
+ */
+expect inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V)

--- a/common/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
+++ b/common/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
@@ -107,3 +107,57 @@ inline infix fun IntRange.shifted(shift: Int): IntRange = (first + shift) .. (la
  * Replaces the value associated with [key] with the value computed by [transform]ing the original value (if any)
  */
 expect inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V)
+
+/**
+ * Drops at most one occurrence of every element inside [elements]. Order of the returned list is not guaranteed! If
+ *  none of the [elements] are present inside this list, the original instance is returned.
+ */
+inline fun <T> List<T>.unorderedDrop(elements: Iterable<T>): List<T> {
+    val iter = elements.iterator()
+    // finding the first one that is actually present
+    while (iter.hasNext()) {
+        val i = indexOf(iter.next())
+        // ensuring there's an element to remove first, allowing us to delay the copy creation as long as possible
+        if (i == -1) {
+            continue
+        }
+        // creating a copy, and removing this element
+        val copy = toMutableList()
+        copy.unorderedDropAt(i)
+        /// continuing with the remainder of the set
+        while (iter.hasNext()) {
+            copy.unorderedDropAt(indexOf(iter.next()))
+        }
+        return copy
+    }
+    return this
+}
+
+/**
+ * Removes element at [index], without! preserving element order for quick removal
+ */
+inline fun <T> MutableList<T>.unorderedDropAt(index: Int) {
+    when {
+        // also covers size == 0
+        index == -1 -> {
+            return
+        }
+        // size = 1, element to be removed = 0 (as it isn't -1), so only clearing the list
+        size == 1 -> {
+            clear()
+        }
+        index == size - 1 -> {
+            removeLast()
+        }
+        else -> {
+            this[index] = removeLast()
+        }
+    }
+}
+
+inline fun <K, V: Any> Iterable<K>.associateWithNotNull(transform: (K) -> V?): Map<K, V> = buildMap {
+    this@associateWithNotNull.forEach { key ->
+        val value = transform(key) ?: return@forEach
+        put(key, value)
+    }
+}

--- a/common/src/jsMain/kotlin/dev/tesserakt/util/CollectionExtensions.js.kt
+++ b/common/src/jsMain/kotlin/dev/tesserakt/util/CollectionExtensions.js.kt
@@ -1,0 +1,5 @@
+package dev.tesserakt.util
+
+actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
+    this[key] = transform(this[key])
+}

--- a/common/src/jvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.jvm.kt
+++ b/common/src/jvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.jvm.kt
@@ -1,0 +1,8 @@
+package dev.tesserakt.util
+
+/**
+ * Replaces the value associated with [key] with the value computed by [transform]ing the original value (if any)
+ */
+actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
+    compute(key) { _, v -> transform(v) }
+}

--- a/common/src/nativeMain/kotlin/dev/tesserakt/util/CollectionExtensions.native.kt
+++ b/common/src/nativeMain/kotlin/dev/tesserakt/util/CollectionExtensions.native.kt
@@ -1,0 +1,5 @@
+package dev.tesserakt.util
+
+actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
+    this[key] = transform(this[key])
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/util/Pattern.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/common/util/Pattern.kt
@@ -8,13 +8,13 @@ import dev.tesserakt.sparql.runtime.core.Mapping
  * Extracts the term value associated with `this` subject based on the provided `mapping`, or `null` if a term
  *  should've been bounded but was not found (i.e. unconstrained)
  */
-fun Pattern.Subject.getTermOrNull(mapping: Mapping): Quad.Term? =
+internal fun Pattern.Subject.getTermOrNull(mapping: Mapping): Quad.Term? =
     when (this) {
         is Pattern.Binding -> mapping[name]
         is Pattern.Exact -> term
     }
 
-fun Pattern.Object.getTermOrNull(mapping: Mapping): Quad.Term? =
+internal fun Pattern.Object.getTermOrNull(mapping: Mapping): Quad.Term? =
     when (this) {
         is Pattern.Binding -> mapping[name]
         is Pattern.Exact -> term

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/core/Mapping.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/core/Mapping.kt
@@ -1,21 +1,40 @@
 package dev.tesserakt.sparql.runtime.core
 
 import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.common.types.Bindings
 import kotlin.jvm.JvmName
 
-typealias Mapping = Map<String, Quad.Term>
+internal class Mapping(private val inner: Map<String, Quad.Term>): Map<String, Quad.Term> by inner {
+    // caching this thing, guaranteed to be static
+    private val hash = inner.hashCode()
 
-fun mappingOf(vararg pairs: Pair<String, Quad.Term>): Mapping = HashMap<String, Quad.Term>(pairs.size)
-    .also { it.putAll(pairs) }
+    val bindings: Bindings get() = inner
+
+    override fun hashCode() = hash
+
+    override fun equals(other: Any?): Boolean = other is Mapping && hash == other.hash && inner == other.inner
+
+    operator fun plus(other: Mapping): Mapping = Mapping(inner = this.inner + other.inner)
+
+    override fun toString() = bindings.toString()
+
+}
+
+internal val EmptyMapping = Mapping(emptyMap())
+
+internal fun mappingOf(vararg pairs: Pair<String, Quad.Term>): Mapping =
+    Mapping(inner = HashMap<String, Quad.Term>(pairs.size).also { it.putAll(pairs) })
 
 @JvmName("mappingOfNullable")
-fun mappingOf(vararg pairs: Pair<String?, Quad.Term>): Mapping = HashMap<String, Quad.Term>(pairs.size)
+internal fun mappingOf(vararg pairs: Pair<String?, Quad.Term>): Mapping = HashMap<String, Quad.Term>(pairs.size)
     .also { map ->
         pairs.forEach { (first, second) ->
             if (first != null) {
                 map[first] = second
             }
         }
-    }
+    }.toMapping()
 
-fun emptyMapping(): Mapping = emptyMap()
+internal fun Bindings.toMapping() = Mapping(inner = this)
+
+internal fun emptyMapping(): Mapping = EmptyMapping

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/HashJoinArray.kt
@@ -2,7 +2,9 @@ package dev.tesserakt.sparql.runtime.incremental.collection
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.core.Mapping
+import dev.tesserakt.sparql.runtime.core.toMapping
 import dev.tesserakt.util.compatibleWith
+import kotlin.jvm.JvmName
 
 /**
  * An array useful for storing a series of mappings, capable of joining with other mappings using the hash join
@@ -11,7 +13,9 @@ import dev.tesserakt.util.compatibleWith
 internal class HashJoinArray(bindings: Set<String>): JoinCollection {
 
     // the backing structure, contains all mappings ever received
-    private val backing = mutableListOf<Mapping>()
+    private val backing = mutableListOf<Mapping?>()
+    // the number of holes in the backing structure, indicative of the
+    private var holes = 0
     // the underlying hash table, mapping the binding name to the map that indexes it on its value, followed by a list
     //  of indices that should be used in the array above - reason for the use of indices is so evaluating multiple
     //  binding constraints only relies on comparing numbers to compare & merge the total resulting set
@@ -28,7 +32,15 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         check(bindings.isNotEmpty()) { "Invalid use of hash join array! No bindings are used!" }
     }
 
-    override val mappings: List<Mapping> get() = backing
+    override val mappings: List<Mapping> get() = if (holes == 0) {
+        // should be valid if we're tracking the holes correctly
+        @Suppress("UNCHECKED_CAST")
+        backing as List<Mapping>
+    } else {
+        backing
+            .also { println("WARN: inefficient mapping retrieval occurred!") }
+            .filterNotNullTo(ArrayList(backing.size - holes))
+    }
 
     /**
      * Denotes the number of matches it contains, useful for quick cardinality calculations (e.g., joining this state
@@ -72,37 +84,32 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
     }
 
     override fun remove(mapping: Mapping) {
-        // TODO(perf): it might be beneficial to simply replace this element `i` with `null`, so only its own indexes
-        //  have to be removed; then a dedicated rebalance method can fill multiple slots at once (avoiding an unnecessarily
-        //  large backing collection)
-        val pos = backing.indexOfLast { it == mapping }
+        holes += 1
+        val pos = find(mapping)
         require(pos != -1) { "$mapping cannot be removed from HashJoinArray - not found!" }
-        backing.removeAt(pos)
-        // the indexes of this mapping have to be removed
-        index.forEach { index ->
-            val value = mapping[index.key]!!
-            index.value[value]!!.remove(pos)
-        }
-        // all subsequent indexes have to be updated as its backing element has been moved
-        index.forEach { index ->
-            index.value.forEach {
-                it.value.forEachIndexed { index, value ->
-                    if (value > pos) {
-                        it.value[index] = value - 1
-                    }
-                }
-            }
+        backing[pos] = null
+        // considering optimising
+        if (shouldOptimise()) {
+            optimise()
         }
     }
 
     override fun removeAll(mappings: Collection<Mapping>) {
-        // TODO(perf): can be improved, see note at single `remove`
-        mappings.forEach { remove(it) }
+        holes += mappings.size
+        mappings.forEach { mapping ->
+            val pos = find(mapping)
+            require(pos != -1) { "$mapping cannot be removed from HashJoinArray - not found!" }
+            backing[pos] = null
+        }
+        // considering optimising
+        if (shouldOptimise()) {
+            optimise()
+        }
     }
 
     override fun join(mapping: Mapping): List<Mapping> {
         val compatible = getCompatibleMappings(mapping)
-        return compatible.mapNotNull { if (it.compatibleWith(mapping)) it + mapping else null }
+        return compatible.mapNotNull { if (it != null && it.compatibleWith(mapping)) it + mapping else null }
     }
 
     override fun join(mappings: List<Mapping>): List<Mapping> {
@@ -112,7 +119,7 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         }
         val compatible = getCompatibleMappings(mappings)
         return compatible.indices.flatMap { i ->
-            compatible[i].mapNotNull { if (it.compatibleWith(mappings[i])) it + mappings[i] else null }
+            compatible[i].mapNotNull { if (it != null && it.compatibleWith(mappings[i])) it + mappings[i] else null }
         }
     }
 
@@ -124,32 +131,128 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         }
     }
 
-    override fun toString(): String =
-        "HashJoinArray (cardinality ${mappings.size}, indexed on ${index.keys.joinToString()})"
+    @JvmName("joinNullable")
+    private fun join(mappings: List<Mapping?>): List<Mapping> {
+        when (mappings.size) {
+            0 -> return emptyList()
+            1 -> return mappings.first()?.let { join(it) } ?: emptyList()
+        }
+        val compatible = getCompatibleMappings(mappings)
+        return compatible.indices.flatMap { i ->
+            val mapping = mappings[i] ?: return@flatMap emptyList()
+            compatible[i].mapNotNull { if (it != null && it.compatibleWith(mapping)) it + mapping else null }
+        }
+    }
 
     /**
-     * Returns a list of all compatible mappings using the provided reference mappings.
+     * Defragments the backing array, setting the hole count to zero, rehashing the existing index accordingly.
      */
-    private fun getCompatibleMappings(references: List<Mapping>): List<List<Mapping>> {
-        // separating the individual references into their constraints
-        val constraints: Map<Mapping, List<Int>> = references.indices.groupBy { i ->
-            val current = references[i]
-            val constraints = current.keys.filter { it in index }.toSet()
-            current.filter { it.key in constraints }
+    fun optimise() {
+        // ignoring optimise requests when there aren't any holes to optimise
+        if (holes == 0) {
+            return
         }
-        // with all relevant & unique constraints formed, the compatible mappings w/o redundant lookup can be retrieved
-        val mapped = constraints.map { (constraints, indexes) -> getCompatibleMappings(constraints) to indexes }
-        // now the map can be "exploded" again into its original form
-        return mapped
-            .flatMapTo(ArrayList(references.size)) { entry -> entry.second.map { i -> i to entry.first } }
-            .sortedBy { it.first }
-            .map { it.second }
+        defragment()
+        rehash()
+    }
+
+    private fun shouldOptimise(): Boolean {
+        // if more than a third of our capacity are holes, or the total hole count exceeds 100, it's probably a good
+        //  idea to optimise
+        return holes > backing.size / 3 || holes > 100
+    }
+
+    /**
+     * Removes the holes from the backing structure, making it possible for the existing capacity to be reused for
+     *  new data.
+     *
+     * IMPORTANT: this should **never** be called without rehashing, as it breaks item positions!
+     */
+    private fun defragment() {
+        // quick fixing the backing array by swapping holes with the final element
+        var i = 0
+        while (i < size - 1) {
+            if (backing[i] == null) {
+                backing[i] = backing.removeLast()
+            } else {
+                ++i
+            }
+        }
+        // trimming the end
+        if (backing.isNotEmpty() && backing.last() == null) {
+            backing.removeLast()
+        }
+        // resetting the hole count
+        holes = 0
+    }
+
+    /**
+     * Recreates the hashes based on the values currently present in the backing structure.
+     *
+     * IMPORTANT: this should not be called when the backing structure contains holes!
+     */
+    private fun rehash() {
+        require(holes == 0) { "Invalid use of the rehashing function!" }
+        // 1: removing existing indices
+        index.forEach { it.value.forEach { it.value.clear() } }
+        // 2: filling it with the new values; we can already ensure it's non-null here, so doing it here to avoid
+        //  the additional check
+        @Suppress("UNCHECKED_CAST")
+        (backing as List<Mapping>).forEachIndexed { i, mapping ->
+            index.forEach { index ->
+                val value = mapping[index.key]
+                    ?: throw IllegalArgumentException("Mapping $mapping has no value required for index `${index.key}`")
+                index.value
+                    .getOrPut(value) { arrayListOf() }
+                    .add(i)
+            }
+        }
+        // 3: clearing the empty index values completely
+        index.forEach { it.value.entries.retainAll { it.value.isNotEmpty() } }
+    }
+
+    /**
+     * Finds the index associated with the [mapping] inside of the [backing] array, or `-1` if it hasn't been found
+     */
+    private fun find(mapping: Mapping): Int {
+        val indices = getCompatibleIndices(mapping)
+        indices.forEach { i ->
+            if (backing[i] == mapping) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    override fun toString(): String =
+        "HashJoinArray (cardinality ${backing.size - holes}, indexed on ${index.keys.joinToString()})"
+
+    /**
+     * Returns an iterable set of indices compatible with the provided mapping
+     */
+    private fun getCompatibleIndices(reference: Mapping): Iterable<Int> {
+        val constraints = reference.filter { it.key in index }
+        // if there aren't any constraints, all mappings (the entire backing array) can be returned instead
+        if (constraints.isEmpty()) {
+            return backing.indices
+        }
+        // getting all relevant indexes - if any of the mapping's values don't have an ID list present for the reference's
+        //  value, we can bail early: none match the reference
+        val indexes = constraints.map { binding -> index[binding.key]!![binding.value] ?: return emptyList() }
+        // the resulting array cannot be longer than the smallest index found, so if any of them are empty, no results
+        //  are found
+        if (indexes.any { it.isEmpty() }) {
+            return emptyList()
+        }
+        // these index arrays are guaranteed to be sorted already (see other notes), so "quickMerge"ing them and mapping
+        //  these indexes to their actual value
+        return quickMerge(indexes)
     }
 
     /**
      * Returns a list of mappings compatible with the provided mapping
      */
-    private fun getCompatibleMappings(reference: Mapping): List<Mapping> {
+    private fun getCompatibleMappings(reference: Mapping): List<Mapping?> {
         val constraints = reference.filter { it.key in index }
         // if there aren't any constraints, all mappings (the entire backing array) can be returned instead
         if (constraints.isEmpty()) {
@@ -166,6 +269,26 @@ internal class HashJoinArray(bindings: Set<String>): JoinCollection {
         // these index arrays are guaranteed to be sorted already (see other notes), so "quickMerge"ing them and mapping
         //  these indexes to their actual value
         return quickMerge(indexes).map { backing[it] }
+    }
+
+    /**
+     * Returns a list of all compatible mappings using the provided reference mappings. References representing a
+     *  non-existent binding (`null`) are automatically associated with an empty list
+     */
+    private fun getCompatibleMappings(references: List<Mapping?>): List<List<Mapping?>> {
+        // separating the individual references into their constraints
+        val constraints: Map<Mapping?, List<Int>> = references.indices.groupBy { i ->
+            val current = references[i] ?: return@groupBy null
+            val constraints = current.keys.filter { it in index }.toSet()
+            current.filter { it.key in constraints }.toMapping()
+        }
+        // with all relevant & unique constraints formed, the compatible mappings w/o redundant lookup can be retrieved
+        val mapped = constraints.map { (constraints, indexes) -> (constraints?.let { getCompatibleMappings(constraints) } ?: emptyList()) to indexes }
+        // now the map can be "exploded" again into its original form
+        return mapped
+            .flatMapTo(ArrayList(references.size)) { entry -> entry.second.map { i -> i to entry.first } }
+            .sortedBy { it.first }
+            .map { it.second }
     }
 
     companion object {

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.runtime.incremental.collection
 
 import dev.tesserakt.sparql.runtime.core.Mapping
 
-interface JoinCollection {
+internal interface JoinCollection {
 
     val mappings: List<Mapping>
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/JoinCollection.kt
@@ -8,9 +8,27 @@ internal interface JoinCollection {
 
     fun join(other: JoinCollection): List<Mapping>
 
+    /**
+     * A specialised variant of the [join] method, where a collection of [Mapping]s [ignore] is skipped at join time,
+     *  acting as if it has been [remove]d
+     */
+    fun join(other: JoinCollection, ignore: Iterable<Mapping>): List<Mapping>
+
     fun join(mapping: Mapping): List<Mapping>
 
+    /**
+     * A specialised variant of the [join] method, where a collection of [Mapping]s [ignore] is skipped at join time,
+     *  acting as if it has been [remove]d
+     */
+    fun join(mapping: Mapping, ignore: Iterable<Mapping>): List<Mapping>
+
     fun join(mappings: List<Mapping>): List<Mapping>
+
+    /**
+     * A specialised variant of the [join] method, where a collection of [Mapping]s [ignore] is skipped at join time,
+     *  acting as if it has been [remove]d
+     */
+    fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping>
 
     fun add(mapping: Mapping)
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
@@ -42,11 +42,23 @@ internal value class NestedJoinArray(
     }
 
     override fun remove(mapping: Mapping) {
-        this.mappings.remove(mapping)
+        val i = this.mappings.indexOfLast { it == mapping }
+        when (i) {
+            -1 -> {
+                throw IllegalStateException("$mapping cannot be removed from NestedJoinArray - not found!")
+            }
+            this.mappings.size - 1 -> {
+                this.mappings.removeLast()
+            }
+            else -> {
+                // putting the last element there instead
+                this.mappings[i] = this.mappings.removeLast()
+            }
+        }
     }
 
     override fun removeAll(mappings: Collection<Mapping>) {
-        this.mappings.removeAll(mappings)
+        mappings.forEach(::remove)
     }
 
     override fun toString() = "NestedJoinArray (cardinality ${mappings.size})"

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/collection/NestedJoinArray.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql.runtime.incremental.collection
 
 import dev.tesserakt.sparql.runtime.core.Mapping
 import dev.tesserakt.util.compatibleWith
+import dev.tesserakt.util.unorderedDrop
 import kotlin.jvm.JvmInline
 
 @JvmInline
@@ -19,6 +20,18 @@ internal value class NestedJoinArray(
         }
     }
 
+    override fun join(other: JoinCollection, ignore: Iterable<Mapping>): List<Mapping> {
+        return if (other is HashJoinArray) {
+            // the ignore parameter has to be applied to the mappings from this collection, so we have to create a new
+            // temporary one
+            val adjusted = mappings.unorderedDrop(ignore)
+            other.join(mappings = adjusted)
+        } else {
+            // hardly ideal to drop them here, without indexing this can be a large collection to iterate over
+            doNestedJoin(a = mappings.unorderedDrop(ignore), b = other.mappings)
+        }
+    }
+
     override fun join(mapping: Mapping): List<Mapping> {
         return buildList(mappings.size) {
             mappings.forEach { contender ->
@@ -29,8 +42,24 @@ internal value class NestedJoinArray(
         }
     }
 
+    override fun join(mapping: Mapping, ignore: Iterable<Mapping>): List<Mapping> {
+        return buildList(mappings.size) {
+            // hardly ideal to drop them here, without indexing this can be a large collection to iterate over
+            mappings.unorderedDrop(ignore).forEach { contender ->
+                if (contender.compatibleWith(mapping)) {
+                    add(contender + mapping)
+                }
+            }
+        }
+    }
+
     override fun join(mappings: List<Mapping>): List<Mapping> {
         return doNestedJoin(a = this.mappings, b = mappings)
+    }
+
+    override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+        // hardly ideal to drop them here, without indexing this can be a large collection to iterate over
+        return doNestedJoin(a = this.mappings.unorderedDrop(ignore), b = mappings)
     }
 
     override fun add(mapping: Mapping) {
@@ -73,4 +102,3 @@ private inline fun doNestedJoin(a: List<Mapping>, b: List<Mapping>) = buildList(
         }
     }
 }
-

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
@@ -16,6 +16,7 @@ sealed interface DataDelta: Delta {
 
 internal sealed interface MappingDelta: Delta {
     val value: Mapping
+    val origin: DataDelta?
 }
 
 @JvmInline
@@ -23,9 +24,11 @@ value class DataAddition(override val value: Quad): AdditionDelta, DataDelta {
     override fun toString() = "Adding of quad $value"
 }
 
-@JvmInline
-internal value class MappingAddition(override val value: Mapping): AdditionDelta, MappingDelta {
-    override fun toString() = "Additional mapping $value"
+internal data class MappingAddition(
+    override val value: Mapping,
+    override val origin: DataDelta?
+): AdditionDelta, MappingDelta {
+    override fun toString() = if (origin != null) "Additional mapping $value, caused by $origin" else "Additional mapping $value"
 }
 
 @JvmInline
@@ -33,7 +36,9 @@ value class DataDeletion(override val value: Quad): DeletionDelta, DataDelta {
     override fun toString() = "Removal of quad $value"
 }
 
-@JvmInline
-internal value class MappingDeletion(override val value: Mapping): DeletionDelta, MappingDelta {
-    override fun toString() = "Removal of mapping $value"
+internal data class MappingDeletion(
+    override val value: Mapping,
+    override val origin: DataDelta?
+): DeletionDelta, MappingDelta {
+    override fun toString() = if (origin != null) "Removal of mapping $value, caused by $origin" else "Removal of mapping $value"
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Delta.kt
@@ -4,38 +4,36 @@ import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.core.Mapping
 import kotlin.jvm.JvmInline
 
-sealed interface Delta {
+sealed interface Delta
 
-    sealed interface Addition: Delta
+sealed interface AdditionDelta: Delta
 
-    sealed interface Deletion: Delta
+sealed interface DeletionDelta: Delta
 
-    sealed interface Data: Delta {
-        val value: Quad
-    }
+sealed interface DataDelta: Delta {
+    val value: Quad
+}
 
-    sealed interface Bindings: Delta {
-        val value: Mapping
-    }
+internal sealed interface MappingDelta: Delta {
+    val value: Mapping
+}
 
-    @JvmInline
-    value class DataAddition(override val value: Quad): Addition, Data {
-        override fun toString() = "Adding of quad $value"
-    }
+@JvmInline
+value class DataAddition(override val value: Quad): AdditionDelta, DataDelta {
+    override fun toString() = "Adding of quad $value"
+}
 
-    @JvmInline
-    value class BindingsAddition(override val value: Mapping): Addition, Bindings {
-        override fun toString() = "Additional mapping $value"
-    }
+@JvmInline
+internal value class MappingAddition(override val value: Mapping): AdditionDelta, MappingDelta {
+    override fun toString() = "Additional mapping $value"
+}
 
-    @JvmInline
-    value class DataDeletion(override val value: Quad): Deletion, Data {
-        override fun toString() = "Removal of quad $value"
-    }
+@JvmInline
+value class DataDeletion(override val value: Quad): DeletionDelta, DataDelta {
+    override fun toString() = "Removal of quad $value"
+}
 
-    @JvmInline
-    value class BindingsDeletion(override val value: Mapping): Deletion, Bindings {
-        override fun toString() = "Removal of mapping $value"
-    }
-
+@JvmInline
+internal value class MappingDeletion(override val value: Mapping): DeletionDelta, MappingDelta {
+    override fun toString() = "Removal of mapping $value"
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
@@ -4,28 +4,28 @@ import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.core.Mapping
 import dev.tesserakt.util.compatibleWith
 
-internal inline fun addition(quad: Quad) = Delta.DataAddition(quad)
+internal inline fun addition(quad: Quad) = DataAddition(quad)
 
-internal inline fun addition(mapping: Mapping) = Delta.BindingsAddition(mapping)
+internal inline fun addition(mapping: Mapping) = MappingAddition(mapping)
 
-operator fun Delta.Bindings.plus(other: Delta.Bindings): Delta.Bindings? {
+internal operator fun MappingDelta.plus(other: MappingDelta): MappingDelta? {
     return when {
-        this is Delta.BindingsAddition &&
-        other is Delta.BindingsAddition &&
+        this is MappingAddition &&
+        other is MappingAddition &&
         value.compatibleWith(other.value) ->
-            Delta.BindingsAddition(value = value + other.value)
+            MappingAddition(value = value + other.value)
 
         else -> null
     }
 }
 
-inline fun Delta.Bindings.map(transform: (Mapping) -> Mapping) = when (this) {
-    is Delta.BindingsAddition -> Delta.BindingsAddition(transform(value))
-    is Delta.BindingsDeletion -> Delta.BindingsDeletion(transform(value))
+internal inline fun MappingDelta.map(transform: (Mapping) -> Mapping) = when (this) {
+    is MappingAddition -> MappingAddition(transform(value))
+    is MappingDeletion -> MappingDeletion(transform(value))
 }
 
 
-inline fun Delta.Bindings.transform(transform: (Mapping) -> Collection<Mapping>) = when (this) {
-    is Delta.BindingsAddition -> transform(value).map { Delta.BindingsAddition(it) }
-    is Delta.BindingsDeletion -> transform(value).map { Delta.BindingsDeletion(it) }
+internal inline fun MappingDelta.transform(transform: (Mapping) -> Collection<Mapping>) = when (this) {
+    is MappingAddition -> transform(value).map { MappingAddition(it) }
+    is MappingDeletion -> transform(value).map { MappingDeletion(it) }
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/delta/Util.kt
@@ -1,31 +1,32 @@
 package dev.tesserakt.sparql.runtime.incremental.delta
 
-import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.core.Mapping
 import dev.tesserakt.util.compatibleWith
 
-internal inline fun addition(quad: Quad) = DataAddition(quad)
-
-internal inline fun addition(mapping: Mapping) = MappingAddition(mapping)
 
 internal operator fun MappingDelta.plus(other: MappingDelta): MappingDelta? {
     return when {
         this is MappingAddition &&
         other is MappingAddition &&
         value.compatibleWith(other.value) ->
-            MappingAddition(value = value + other.value)
+            MappingAddition(value = value + other.value, origin = origin)
+
+        this is MappingDeletion &&
+        other is MappingDeletion &&
+        value.compatibleWith(other.value) ->
+            MappingDeletion(value = value + other.value, origin = origin)
 
         else -> null
     }
 }
 
 internal inline fun MappingDelta.map(transform: (Mapping) -> Mapping) = when (this) {
-    is MappingAddition -> MappingAddition(transform(value))
-    is MappingDeletion -> MappingDeletion(transform(value))
+    is MappingAddition -> MappingAddition(transform(value), origin = origin)
+    is MappingDeletion -> MappingDeletion(transform(value), origin = origin)
 }
 
 
 internal inline fun MappingDelta.transform(transform: (Mapping) -> Collection<Mapping>) = when (this) {
-    is MappingAddition -> transform(value).map { MappingAddition(it) }
-    is MappingDeletion -> transform(value).map { MappingDeletion(it) }
+    is MappingAddition -> transform(value).map { MappingAddition(it, origin = origin) }
+    is MappingDeletion -> transform(value).map { MappingDeletion(it, origin = origin) }
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
@@ -6,6 +6,7 @@ import dev.tesserakt.sparql.runtime.common.types.Bindings
 import dev.tesserakt.sparql.runtime.incremental.delta.DataAddition
 import dev.tesserakt.sparql.runtime.incremental.delta.DataDeletion
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery
+import dev.tesserakt.util.replace
 
 
 class OngoingQueryEvaluation<RT>(private val query: IncrementalQuery<RT, *>) {
@@ -54,15 +55,14 @@ class OngoingQueryEvaluation<RT>(private val query: IncrementalQuery<RT, *>) {
     private fun process(change: IncrementalQuery.ResultChange<Bindings>) {
         when (val mapped = query.process(change)) {
             is IncrementalQuery.ResultChange.New<*> -> {
-                _results[mapped.value] = (_results[mapped.value] ?: 0) + 1
+                _results.replace(mapped.value) { current -> (current ?: 0) + 1 }
             }
             is IncrementalQuery.ResultChange.Removed<*> -> {
-                val current = _results[mapped.value]
-                    ?: throw IllegalStateException("Could not remove ${mapped.value} from the result list as it did not exist!")
-                if (current == 1) {
-                     _results.remove(mapped.value)
-                } else {
-                    _results[mapped.value] = current - 1
+                _results.replace(mapped.value) { current ->
+                    when (current) {
+                        null, 0 -> throw IllegalStateException("Could not remove ${mapped.value} from the result list as it did not exist!")
+                        else -> current - 1
+                    }
                 }
             }
         }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/OngoingQueryEvaluation.kt
@@ -3,14 +3,15 @@ package dev.tesserakt.sparql.runtime.incremental.evaluation
 import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.types.Bindings
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.DataAddition
+import dev.tesserakt.sparql.runtime.incremental.delta.DataDeletion
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery
 
 
 class OngoingQueryEvaluation<RT>(private val query: IncrementalQuery<RT, *>) {
 
-    private val _results = mutableListOf<RT>()
-    val results get() = _results.toList()
+    private val _results = mutableMapOf<RT, Int>()
+    val results get() = _results.flatMap { entry -> List(entry.value) { entry.key } }
 
     private val processor = query.Processor()
 
@@ -26,12 +27,14 @@ class OngoingQueryEvaluation<RT>(private val query: IncrementalQuery<RT, *>) {
 
     init {
         // setting the query state as the current results
-        _results.addAll(processor.state())
+        processor.state().forEach {
+            _results[it] = 1
+        }
     }
 
     fun subscribe(store: MutableStore) {
         store.forEach { quad ->
-            processor.process(Delta.DataAddition(quad)).forEach { process(it) }
+            processor.process(DataAddition(quad)).forEach { process(it) }
         }
         store.addListener(listener)
     }
@@ -41,17 +44,27 @@ class OngoingQueryEvaluation<RT>(private val query: IncrementalQuery<RT, *>) {
     }
 
     fun add(quad: Quad) {
-        processor.process(Delta.DataAddition(quad)).forEach { process(it) }
+        processor.process(DataAddition(quad)).forEach { process(it) }
     }
 
     fun remove(quad: Quad) {
-        processor.process(Delta.DataDeletion(quad)).forEach { process(it) }
+        processor.process(DataDeletion(quad)).forEach { process(it) }
     }
 
     private fun process(change: IncrementalQuery.ResultChange<Bindings>) {
         when (val mapped = query.process(change)) {
-            is IncrementalQuery.ResultChange.New<*> -> _results.add(mapped.value)
-            is IncrementalQuery.ResultChange.Removed<*> -> _results.remove(mapped.value)
+            is IncrementalQuery.ResultChange.New<*> -> {
+                _results[mapped.value] = (_results[mapped.value] ?: 0) + 1
+            }
+            is IncrementalQuery.ResultChange.Removed<*> -> {
+                val current = _results[mapped.value]
+                    ?: throw IllegalStateException("Could not remove ${mapped.value} from the result list as it did not exist!")
+                if (current == 1) {
+                     _results.remove(mapped.value)
+                } else {
+                    _results[mapped.value] = current - 1
+                }
+            }
         }
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/Query.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/evaluation/Query.kt
@@ -3,7 +3,7 @@ package dev.tesserakt.sparql.runtime.incremental.evaluation
 import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.common.util.Debug
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.DataAddition
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery
 
 
@@ -17,7 +17,7 @@ fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>, callback: (Increme
     // now incrementally evaluating the input
     val it = iterator()
     while (it.hasNext()) {
-        processor.process(Delta.DataAddition(it.next())).forEach {
+        processor.process(DataAddition(it.next())).forEach {
             val mapped = query.process(it)
             callback(mapped)
         }
@@ -33,7 +33,7 @@ fun <RT> Iterable<Quad>.query(query: IncrementalQuery<RT, *>): List<RT> = buildL
     // now incrementally evaluating the input
     val it = this@query.iterator()
     while (it.hasNext()) {
-        processor.process(Delta.DataAddition(it.next())).forEach {
+        processor.process(DataAddition(it.next())).forEach {
             when (val mapped = query.process(it)) {
                 is IncrementalQuery.ResultChange.New<RT> -> add(mapped.value)
                 is IncrementalQuery.ResultChange.Removed<RT> -> remove(mapped.value)

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
@@ -2,7 +2,10 @@ package dev.tesserakt.sparql.runtime.incremental.query
 
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 import dev.tesserakt.sparql.runtime.core.emptyMapping
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.DataDelta
+import dev.tesserakt.sparql.runtime.incremental.delta.MappingAddition
+import dev.tesserakt.sparql.runtime.incremental.delta.MappingDeletion
+import dev.tesserakt.sparql.runtime.incremental.delta.MappingDelta
 import dev.tesserakt.sparql.runtime.incremental.query.IncrementalQuery.ResultChange.Companion.into
 import dev.tesserakt.sparql.runtime.incremental.state.IncrementalBasicGraphPatternState
 import dev.tesserakt.sparql.runtime.incremental.types.Query
@@ -23,12 +26,12 @@ sealed class IncrementalQuery<ResultType, Q: Query>(
         fun state(): List<ResultType> {
             return state
                 // getting all current results by joining with an empty new mapping
-                .join(Delta.BindingsAddition(emptyMapping()))
+                .join(MappingAddition(emptyMapping()))
                 // mapping them to insertion changes, combining them into the expected return type
                 .map { bindings -> this@IncrementalQuery.process(ResultChange.New(bindings.value)).value }
         }
 
-        fun process(data: Delta.Data): List<ResultChange<Bindings>> {
+        fun process(data: DataDelta): List<ResultChange<Bindings>> {
             return state.insert(data).map { it.into() }
         }
 
@@ -46,9 +49,9 @@ sealed class IncrementalQuery<ResultType, Q: Query>(
         value class Removed<T>(override val value: T): ResultChange<T>
 
         companion object {
-            fun Delta.Bindings.into() = when (this) {
-                is Delta.BindingsAddition -> New(value)
-                is Delta.BindingsDeletion -> Removed(value)
+            internal fun MappingDelta.into() = when (this) {
+                is MappingAddition -> New(value.bindings)
+                is MappingDeletion -> Removed(value.bindings)
             }
         }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalQuery.kt
@@ -26,7 +26,7 @@ sealed class IncrementalQuery<ResultType, Q: Query>(
         fun state(): List<ResultType> {
             return state
                 // getting all current results by joining with an empty new mapping
-                .join(MappingAddition(emptyMapping()))
+                .join(MappingAddition(value = emptyMapping(), origin = null))
                 // mapping them to insertion changes, combining them into the expected return type
                 .map { bindings -> this@IncrementalQuery.process(ResultChange.New(bindings.value)).value }
         }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
@@ -9,8 +9,8 @@ class IncrementalSelectQuery internal constructor(ast: SelectQuery): Incremental
 
     override fun process(change: ResultChange<Bindings>): ResultChange<Bindings> {
         return when (change) {
-            is ResultChange.New -> ResultChange.New(change.value.filterKeys { name -> name in variables })
-            is ResultChange.Removed -> ResultChange.Removed(change.value.filterKeys { name -> name in variables })
+            is ResultChange.New -> ResultChange.New(variables.associateWith { change.value[it]!! })
+            is ResultChange.Removed -> ResultChange.Removed(variables.associateWith { change.value[it]!! })
         }
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/query/IncrementalSelectQuery.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql.runtime.incremental.query
 
 import dev.tesserakt.sparql.runtime.common.types.Bindings
 import dev.tesserakt.sparql.runtime.incremental.types.SelectQuery
+import dev.tesserakt.util.associateWithNotNull
 
 class IncrementalSelectQuery internal constructor(ast: SelectQuery): IncrementalQuery<Bindings, SelectQuery>(ast) {
 
@@ -9,8 +10,8 @@ class IncrementalSelectQuery internal constructor(ast: SelectQuery): Incremental
 
     override fun process(change: ResultChange<Bindings>): ResultChange<Bindings> {
         return when (change) {
-            is ResultChange.New -> ResultChange.New(variables.associateWith { change.value[it]!! })
-            is ResultChange.Removed -> ResultChange.Removed(variables.associateWith { change.value[it]!! })
+            is ResultChange.New -> ResultChange.New(variables.associateWithNotNull { change.value[it] })
+            is ResultChange.Removed -> ResultChange.Removed(variables.associateWithNotNull { change.value[it] })
         }
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalBasicGraphPatternState.kt
@@ -1,6 +1,7 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.DataDelta
+import dev.tesserakt.sparql.runtime.incremental.delta.MappingDelta
 import dev.tesserakt.sparql.runtime.incremental.types.Query
 import dev.tesserakt.sparql.runtime.util.getAllNamedBindings
 
@@ -15,24 +16,24 @@ internal class IncrementalBasicGraphPatternState(ast: Query.QueryBody) {
      */
     val bindings: Set<String> = ast.getAllNamedBindings().map { it.name }.toSet()
 
-    fun insert(delta: Delta.Data): List<Delta.Bindings> {
+    fun insert(delta: DataDelta): List<MappingDelta> {
         val total = peek(delta)
         process(delta)
         return total
     }
 
-    fun peek(delta: Delta.Data): List<Delta.Bindings> {
+    fun peek(delta: DataDelta): List<MappingDelta> {
         val first = patterns.peek(delta)
         val second = unions.peek(delta)
         return patterns.join(second) + unions.join(first)
     }
 
-    fun process(delta: Delta.Data) {
+    fun process(delta: DataDelta) {
         patterns.process(delta)
         unions.process(delta)
     }
 
-    fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+    fun join(delta: MappingDelta): List<MappingDelta> {
         return unions.join(patterns.join(delta))
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalPathState.kt
@@ -97,6 +97,10 @@ internal sealed class IncrementalPathState {
             return arr.join(mappings)
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
+        }
+
         override fun toString() = segments.toString()
 
     }
@@ -191,6 +195,10 @@ internal sealed class IncrementalPathState {
             return arr.join(mappings)
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
+        }
+
         override fun toString() = segments.toString()
 
     }
@@ -266,6 +274,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return arr.join(mappings)
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
         }
 
         override fun toString() = segments.toString()
@@ -354,6 +366,10 @@ internal sealed class IncrementalPathState {
             return arr.join(mappings)
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
+        }
+
         override fun toString() = segments.toString()
 
     }
@@ -429,6 +445,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return arr.join(mappings)
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
         }
 
         override fun toString() = segments.toString()
@@ -514,6 +534,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return arr.join(mappings)
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
         }
 
         override fun toString() = segments.toString()
@@ -607,6 +631,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return if (satisfied) mappings else emptyList()
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            TODO("Not yet implemented")
         }
 
     }
@@ -724,6 +752,10 @@ internal sealed class IncrementalPathState {
             return if (satisfied) mappings else emptyList()
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            TODO("Not yet implemented")
+        }
+
     }
 
     class OneOrMoreStatelessBindings(
@@ -774,6 +806,10 @@ internal sealed class IncrementalPathState {
             return arr.join(mappings)
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
+        }
+
         override fun toString() = segments.toString()
 
     }
@@ -820,6 +856,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return arr.join(mappings)
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
         }
 
         override fun toString() = segments.toString()
@@ -877,6 +917,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return arr.join(mappings)
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
         }
 
         override fun toString() = segments.toString()
@@ -951,6 +995,10 @@ internal sealed class IncrementalPathState {
             return arr.join(mappings)
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
+        }
+
         override fun toString() = segments.toString()
 
         private fun getNewSegments(quad: Quad): Set<SegmentsList.Segment> {
@@ -1006,6 +1054,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return arr.join(mappings)
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
         }
 
         override fun toString() = segments.toString()
@@ -1080,6 +1132,10 @@ internal sealed class IncrementalPathState {
             return arr.join(mappings)
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            return arr.join(mappings, ignore = ignore)
+        }
+
         override fun toString() = segments.toString()
 
         private fun getNewSegments(quad: Quad): Set<SegmentsList.Segment> {
@@ -1128,6 +1184,10 @@ internal sealed class IncrementalPathState {
 
         override fun join(mappings: List<Mapping>): List<Mapping> {
             return if (satisfied) mappings else emptyList()
+        }
+
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            TODO("Not yet implemented")
         }
 
     }
@@ -1202,6 +1262,10 @@ internal sealed class IncrementalPathState {
             return if (satisfied) mappings else emptyList()
         }
 
+        override fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping> {
+            TODO("Not yet implemented")
+        }
+
     }
 
 
@@ -1214,6 +1278,8 @@ internal sealed class IncrementalPathState {
     abstract fun peek(deletion: DataDeletion): List<Mapping>
 
     abstract fun join(mappings: List<Mapping>): List<Mapping>
+
+    abstract fun join(mappings: List<Mapping>, ignore: Iterable<Mapping>): List<Mapping>
 
     companion object {
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/IncrementalUnionState.kt
@@ -1,6 +1,7 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.DataDelta
+import dev.tesserakt.sparql.runtime.incremental.delta.MappingDelta
 import dev.tesserakt.sparql.runtime.incremental.types.SelectQuerySegment
 import dev.tesserakt.sparql.runtime.incremental.types.StatementsSegment
 import dev.tesserakt.sparql.runtime.incremental.types.Union
@@ -15,15 +16,15 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
             override val bindings: Set<String> get() = state.bindings
 
-            override fun peek(delta: Delta.Data): List<Delta.Bindings> {
+            override fun peek(delta: DataDelta): List<MappingDelta> {
                 return state.peek(delta)
             }
 
-            override fun process(delta: Delta.Data) {
+            override fun process(delta: DataDelta) {
                 return state.process(delta)
             }
 
-            override fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+            override fun join(delta: MappingDelta): List<MappingDelta> {
                 return state.join(delta)
             }
 
@@ -33,15 +34,15 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
             override val bindings: Set<String> = parent.query.output.map { it.name }.toSet()
 
-            override fun peek(delta: Delta.Data): List<Delta.Bindings> {
+            override fun peek(delta: DataDelta): List<MappingDelta> {
                 TODO("Not yet implemented")
             }
 
-            override fun process(delta: Delta.Data) {
+            override fun process(delta: DataDelta) {
                 TODO("Not yet implemented")
             }
 
-            override fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+            override fun join(delta: MappingDelta): List<MappingDelta> {
                 TODO("Not yet implemented")
             }
 
@@ -49,11 +50,11 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
         abstract val bindings: Set<String>
 
-        abstract fun peek(delta: Delta.Data): List<Delta.Bindings>
+        abstract fun peek(delta: DataDelta): List<MappingDelta>
 
-        abstract fun process(delta: Delta.Data)
+        abstract fun process(delta: DataDelta)
 
-        abstract fun join(delta: Delta.Bindings): List<Delta.Bindings>
+        abstract fun join(delta: MappingDelta): List<MappingDelta>
 
     }
 
@@ -61,15 +62,15 @@ internal class IncrementalUnionState(union: Union): MutableJoinState {
 
     override val bindings: Set<String> = buildSet { state.forEach { addAll(it.bindings) } }
 
-    override fun process(delta: Delta.Data) {
+    override fun process(delta: DataDelta) {
         state.forEach { it.process(delta) }
     }
 
-    override fun peek(delta: Delta.Data): List<Delta.Bindings> {
+    override fun peek(delta: DataDelta): List<MappingDelta> {
         return state.flatMap { it.peek(delta) }
     }
 
-    override fun join(delta: Delta.Bindings): List<Delta.Bindings> {
+    override fun join(delta: MappingDelta): List<MappingDelta> {
         return state.flatMap { s -> s.join(delta) }
     }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/JoinTree.kt
@@ -19,6 +19,24 @@ import kotlin.jvm.JvmName
  */
 internal sealed interface JoinTree {
 
+    data object Empty: JoinTree {
+
+        override fun peek(delta: DataDelta): List<MappingDelta> {
+            return emptyList()
+        }
+
+        override fun process(delta: DataDelta) {
+            // nothing to do
+        }
+
+        override fun join(delta: MappingDelta): List<MappingDelta> {
+            return listOf(delta)
+        }
+
+        override fun toString(): String = "Empty join tree"
+
+    }
+
     /**
      * Non-existent join tree
      */
@@ -346,7 +364,8 @@ internal sealed interface JoinTree {
         operator fun invoke(patterns: List<Pattern>) = when {
             // TODO(perf) specialised empty case
             // TODO(perf) also based on binding overlap
-            patterns.size >= 3 -> LeftDeep(patterns)
+//            patterns.size >= 3 -> LeftDeep(patterns)
+            patterns.isEmpty() -> Empty
             else -> None(patterns)
         }
 
@@ -354,7 +373,8 @@ internal sealed interface JoinTree {
         operator fun invoke(unions: List<Union>) = when {
             // TODO(perf) specialised empty case
             // TODO(perf) also based on binding overlap
-            unions.size >= 3 -> LeftDeep(unions)
+//            unions.size >= 3 -> LeftDeep(unions)
+            unions.isEmpty() -> Empty
             else -> None(unions)
         }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MutableJoinState.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/MutableJoinState.kt
@@ -1,6 +1,7 @@
 package dev.tesserakt.sparql.runtime.incremental.state
 
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.DataDelta
+import dev.tesserakt.sparql.runtime.incremental.delta.MappingDelta
 
 /**
  * Represents a state type that can be joined with other states of the same (sub-) type, such as triple patterns or
@@ -10,17 +11,17 @@ internal interface MutableJoinState {
 
     val bindings: Set<String>
 
-    fun join(delta: Delta.Bindings): List<Delta.Bindings>
+    fun join(delta: MappingDelta): List<MappingDelta>
 
     /**
-     * Returns the [Delta.Bindings] changes that occur when [process]ing the [delta] in this state, without
+     * Returns the [MappingDelta] changes that occur when [process]ing the [delta] in this state, without
      *  actually modifying it (see [process] for mutating the state)
      */
-    fun peek(delta: Delta.Data): List<Delta.Bindings>
+    fun peek(delta: DataDelta): List<MappingDelta>
 
     /**
      * Updates the internal state according to the [delta] change.
      */
-    fun process(delta: Delta.Data)
+    fun process(delta: DataDelta)
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.runtime.incremental.state
 
 import dev.tesserakt.sparql.runtime.common.types.Pattern
 import dev.tesserakt.sparql.runtime.core.pattern.bindingName
-import dev.tesserakt.sparql.runtime.incremental.delta.Delta
+import dev.tesserakt.sparql.runtime.incremental.delta.MappingDelta
 import dev.tesserakt.sparql.runtime.incremental.delta.plus
 import dev.tesserakt.sparql.runtime.util.Bitmask
 
@@ -10,7 +10,7 @@ import dev.tesserakt.sparql.runtime.util.Bitmask
  * Adds all results found inside `this` list together where compatible as additional contenders for complete result
  *  generation (for input quads matching multiple patterns at once)
  */
-internal inline fun List<Pair<Bitmask, List<Delta.Bindings>>>.expandBindingDeltas(): List<Pair<Bitmask, List<Delta.Bindings>>> {
+internal inline fun List<Pair<Bitmask, List<MappingDelta>>>.expandBindingDeltas(): List<Pair<Bitmask, List<MappingDelta>>> {
     val result = toMutableList()
     var i = 0
     while (i < result.size - 1) {
@@ -42,7 +42,7 @@ internal inline fun bindingNamesOf(
     `object`: Pattern.Object
 ): Set<String> = setOfNotNull(subject.bindingName, predicate.bindingName, `object`.bindingName)
 
-internal inline fun JoinTree.join(deltas: List<Delta.Bindings>): List<Delta.Bindings> {
+internal inline fun JoinTree.join(deltas: List<MappingDelta>): List<MappingDelta> {
     return deltas.flatMap { delta -> join(delta) }
 }
 

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/incremental/state/Util.kt
@@ -22,9 +22,7 @@ internal inline fun List<Pair<Bitmask, List<MappingDelta>>>.expandBindingDeltas(
                 return@forEach
             }
             // creating all mappings that result from combining these two sub-results
-            val merged = current.second.flatMap { solution ->
-                contender.second.mapNotNull { candidate -> solution + candidate }
-            }
+            val merged = merge(current.second, contender.second)
             // if any have been made, its combination can be appended to this result
             if (merged.isNotEmpty()) {
                 result.add(current.first or contender.first to merged)
@@ -35,6 +33,11 @@ internal inline fun List<Pair<Bitmask, List<MappingDelta>>>.expandBindingDeltas(
     // TODO(perf): simplify the result: [+ {a}, + {b}, - {a}] == [+ {b}]
     return result
 }
+
+internal fun merge(a: List<MappingDelta>, b: List<MappingDelta>): List<MappingDelta> =
+    buildList(a.size + b.size) {
+        a.forEach { one -> b.forEach { two -> (one + two)?.let { merged -> add(merged) } } }
+    }
 
 internal inline fun bindingNamesOf(
     subject: Pattern.Subject,


### PR DESCRIPTION
Fixed the poor performance that could be observed when issuing deletions on ongoing queries with a large number of output bindings, where it would linearly search what output results to remove. As a result, the new approach now first validates the existence of the output bindings affected by a deletion, which highlighted a series of deletion implementation errors.

New methods to join collections were added to resolve these lingering deletion issues, allowing joins to occur whilst disregarding data temporarily, which is necessary for the deletion `peek` implementation to occur correctly (avoiding data to join onto itself as it is part of that join collection).

Finally, the LeftDeep join tree implementation has not been fixed, and can still fail during certain deletions. This implementation has now been disabled. Instead, a new join tree, Dynamic, has been added, and shows promising performance improvements, whilst having correct behaviour, and can more easily be expanded upon for further query optimisations.

Scattered across this MR, additional small code tweaks have been made to further enhance the performance. This performance analysis was done using flame graphs.