### PR TITLE
Test filtering implementation

### DIFF
--- a/benchmarking/src/commonMain/kotlin/Main.kt
+++ b/benchmarking/src/commonMain/kotlin/Main.kt
@@ -1,27 +1,26 @@
 
 import dev.tesserakt.util.printerrln
 import sparql.tests.*
-import sparql.types.QueryExecutionTest
-import sparql.types.test
+import sparql.types.QueryExecutionTestValues
 
 suspend fun run(args: Array<String>) {
     when (args.size) {
         0 -> {
             println("Running built-in tests")
             val one = compareIncrementalChainSelectOutput(seed = 1)
-                .test(QueryExecutionTest::toOutputComparisonTest)
+                .test(QueryExecutionTestValues::toOutputComparisonTest)
                 .run()
             val two = compareIncrementalStarSelectOutput(seed = 1)
-                .test(QueryExecutionTest::toOutputComparisonTest)
+                .test(QueryExecutionTestValues::toOutputComparisonTest)
                 .run()
             val three = builtinTests()
-                .test(QueryExecutionTest::toOutputComparisonTest)
+                .test(QueryExecutionTestValues::toOutputComparisonTest)
                 .run()
             val four = builtinTests()
-                .test(QueryExecutionTest::toIncrementalUpdateTest)
+                .test(QueryExecutionTestValues::toIncrementalUpdateTest)
                 .run()
             val five = builtinTests()
-                .test(QueryExecutionTest::toRandomUpdateTest)
+                .test(QueryExecutionTestValues::toRandomUpdateTest)
                 .run()
             one.report()
             two.report()
@@ -36,7 +35,7 @@ suspend fun run(args: Array<String>) {
         2 -> {
             val (dataset, querypath) = args
             compareIncrementalBasicGraphPatternOutput(datasetFilepath = dataset, queryFilepath = querypath)
-                .test(QueryExecutionTest::toOutputComparisonTest)
+                .test(QueryExecutionTestValues::toOutputComparisonTest)
                 .run()
                 .report()
         }

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/DefaultTestFiltering.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/DefaultTestFiltering.kt
@@ -1,0 +1,66 @@
+package sparql.tests
+
+import dev.tesserakt.sparql.types.*
+import dev.tesserakt.testing.Test
+import dev.tesserakt.testing.TestFilter
+import sparql.types.QueryExecutionTest
+
+object DefaultTestFiltering: TestFilter {
+
+    override fun shouldSkip(test: Test): Boolean {
+        if (test !is QueryExecutionTest) {
+            return true
+        }
+        val structure = test.structure
+        return shouldSkip(structure)
+    }
+
+    private fun shouldSkip(structure: QueryStructure): Boolean {
+        return structure.body.has { it.p.containsRepeatingPredicate() }
+    }
+
+    fun GraphPattern.has(callback: (pattern: TriplePattern) -> Boolean): Boolean {
+        if (patterns.any(callback)) {
+            return true
+        }
+        filters.forEach { filter ->
+            when (filter) {
+                is Filter.Exists -> if (filter.pattern.has(callback)) {
+                    return true
+                }
+                is Filter.NotExists -> if (filter.pattern.has(callback)) {
+                    return true
+                }
+                else -> { /* nothing to do */ }
+            }
+        }
+        unions.forEach { union ->
+            union.segments.forEach { segment ->
+                when (segment) {
+                    is GraphPatternSegment -> if (segment.pattern.has(callback)) {
+                        return true
+                    }
+                    is SelectQuerySegment -> if (segment.query.body.has(callback)) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    private fun TriplePattern.Predicate.containsRepeatingPredicate(): Boolean {
+        return when (this) {
+            is TriplePattern.OneOrMore -> true
+            is TriplePattern.ZeroOrMore -> true
+            is TriplePattern.UnboundSequence -> chain.any { it.containsRepeatingPredicate() }
+            is TriplePattern.Sequence -> chain.any { it.containsRepeatingPredicate() }
+            is TriplePattern.Alts -> allowed.any { it.containsRepeatingPredicate() }
+            is TriplePattern.SimpleAlts -> false
+            is TriplePattern.Negated -> false
+            is TriplePattern.Exact -> false
+            is TriplePattern.Binding -> false
+        }
+    }
+
+}

--- a/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -20,6 +20,8 @@ object FOAF: Ontology {
 }
 
 fun builtinTests() = tests {
+    filter = DefaultTestFiltering
+
     val small = buildStore {
         val subj = local("s")
         val obj = local("o")

--- a/benchmarking/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/OutputComparisonTest.kt
@@ -2,7 +2,6 @@ package sparql.types
 
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Bindings
-import dev.tesserakt.sparql.Query
 import dev.tesserakt.sparql.query
 import dev.tesserakt.sparql.runtime.RuntimeStatistics
 import dev.tesserakt.testing.Test
@@ -12,17 +11,18 @@ import sparql.ExternalQueryExecution
 import kotlin.time.Duration
 import kotlin.time.measureTime
 
-data class OutputComparisonTest(
-    val query: String,
-    val store: Store
-) : Test {
+class OutputComparisonTest(
+    query: String,
+    store: Store
+) : QueryExecutionTest(query, store) {
+
 
     override suspend fun test() = runTest {
         val actual: List<Bindings>
         val elapsedTime = measureTime {
-            actual = store.query(Query.Select(query))
+            actual = store.query(query)
         }
-        val external = ExternalQueryExecution(query, store)
+        val external = ExternalQueryExecution(queryString, store)
         val expected: List<Bindings>
         val referenceTime = measureTime {
             try {
@@ -42,7 +42,7 @@ data class OutputComparisonTest(
 
     override fun toString(): String =
         "Incremental SPARQL output comparison test\n * Query: `${
-            query.replace(Regex("\\s+"), " ").trim()
+            queryString.replace(Regex("\\s+"), " ").trim()
         }`\n * Input: store with ${store.size} quad(s)"
 
     data class Result(

--- a/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTest.kt
@@ -1,16 +1,16 @@
 package sparql.types
 
 import dev.tesserakt.rdf.types.Store
+import dev.tesserakt.sparql.Compiler
+import dev.tesserakt.sparql.Query
+import dev.tesserakt.testing.Test
 
-data class QueryExecutionTest(
-    val query: String,
+abstract class QueryExecutionTest(
+    val queryString: String,
     val store: Store
-) {
+): Test {
 
-    fun toOutputComparisonTest() = OutputComparisonTest(query = query, store = store)
-
-    fun toIncrementalUpdateTest() = IncrementalUpdateTest(query = query, store = store)
-
-    fun toRandomUpdateTest() = RandomUpdateTest(query = query, store = store)
+    val structure = Compiler().compile(queryString).structure
+    val query = Query.Select(queryString)
 
 }

--- a/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTestValues.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/QueryExecutionTestValues.kt
@@ -1,0 +1,16 @@
+package sparql.types
+
+import dev.tesserakt.rdf.types.Store
+
+data class QueryExecutionTestValues(
+    val query: String,
+    val store: Store
+) {
+
+    fun toOutputComparisonTest() = OutputComparisonTest(query = query, store = store)
+
+    fun toIncrementalUpdateTest() = IncrementalUpdateTest(query = query, store = store)
+
+    fun toRandomUpdateTest() = RandomUpdateTest(query = query, store = store)
+
+}

--- a/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/Util.kt
@@ -3,28 +3,33 @@ package sparql.types
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Bindings
 import dev.tesserakt.testing.Test
+import dev.tesserakt.testing.TestFilter
 import dev.tesserakt.testing.testEnv
 import kotlin.time.Duration
 
 class TestBuilderEnv {
 
-    val tests = mutableListOf<QueryExecutionTest>()
+    var filter: TestFilter = TestFilter.Default
+    val tests = mutableListOf<QueryExecutionTestValues>()
 
     fun using(store: Store) = TestBuilder(environment = this, store = store)
+
+    fun test(mapper: (QueryExecutionTestValues) -> Test) = testEnv {
+        filter = this@TestBuilderEnv.filter
+        tests.forEach { add(mapper(it)) }
+    }
 
 }
 
 class TestBuilder(private val environment: TestBuilderEnv, private val store: Store) {
 
     infix fun test(query: String) {
-        environment.tests.add(QueryExecutionTest(query = query, store = store))
+        environment.tests.add(QueryExecutionTestValues(query = query, store = store))
     }
 
 }
 
-inline fun tests(block: TestBuilderEnv.() -> Unit) = TestBuilderEnv().apply(block).tests.toList()
-
-inline fun List<QueryExecutionTest>.test(mapper: (QueryExecutionTest) -> Test) = testEnv { forEach { add(mapper(it)) } }
+inline fun tests(block: TestBuilderEnv.() -> Unit) = TestBuilderEnv().apply(block)
 
 /**
  * Returns the diff of the two series of bindings. Ideally, the returned list is empty

--- a/testing/suite/src/commonMain/kotlin/dev/tesserakt/testing/Test.kt
+++ b/testing/suite/src/commonMain/kotlin/dev/tesserakt/testing/Test.kt
@@ -8,6 +8,12 @@ fun interface Test {
 
     interface Result {
 
+        data object Skipped : Result {
+            // not considered a failure
+            override fun isSuccess(): Boolean = true
+            override fun exceptionOrNull(): Throwable? = null
+        }
+
         fun isSuccess(): Boolean
 
         fun exceptionOrNull(): Throwable?

--- a/testing/suite/src/commonMain/kotlin/dev/tesserakt/testing/TestFilter.kt
+++ b/testing/suite/src/commonMain/kotlin/dev/tesserakt/testing/TestFilter.kt
@@ -1,0 +1,13 @@
+package dev.tesserakt.testing
+
+fun interface TestFilter {
+
+    object Default: TestFilter {
+        override fun shouldSkip(test: Test): Boolean {
+            return false
+        }
+    }
+
+    fun shouldSkip(test: Test): Boolean
+
+}


### PR DESCRIPTION
Added test filters to the test environment, used to skip test execution based on custom logic
Implemented test skipping filters for all queries containing repeating patterns, as these are not fully implemented, guaranteeing test failure