### PR TITLE
Sequence path evaluation & data stream reuse fixes

### DIFF
--- a/benchmarking/src/commonMain/kotlin/sparql/types/IncrementalUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/IncrementalUpdateTest.kt
@@ -39,7 +39,8 @@ class IncrementalUpdateTest(
         // checking the initial state (no data)
         builder.add(
             self = setupTime to ongoing.results,
-            reference = reference()
+            reference = reference(),
+            debugInformation = ongoing.debugInformation()
         )
         // building it up
         store.forEach { quad ->
@@ -50,7 +51,8 @@ class IncrementalUpdateTest(
             }
             builder.add(
                 self = elapsedTime to current,
-                reference = reference()
+                reference = reference(),
+                debugInformation = ongoing.debugInformation()
             )
         }
         // breaking it back down
@@ -62,7 +64,8 @@ class IncrementalUpdateTest(
             }
             builder.add(
                 self = elapsedTime to current,
-                reference = reference()
+                reference = reference(),
+                debugInformation = ongoing.debugInformation()
             )
         }
         builder.build()
@@ -85,6 +88,7 @@ class IncrementalUpdateTest(
             fun add(
                 self: Pair<Duration, List<Bindings>>,
                 reference: Pair<Duration, List<Bindings>>,
+                debugInformation: String,
             ) {
                 list.add(
                     compare(
@@ -92,7 +96,7 @@ class IncrementalUpdateTest(
                         elapsedTime = self.first,
                         expected = reference.second,
                         referenceTime = reference.first,
-                        debugInformation = ""
+                        debugInformation = debugInformation
                     )
                 )
             }

--- a/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
@@ -60,7 +60,8 @@ class RandomUpdateTest(
         // checking the initial state (no data)
         builder.add(
             self = setupTime to ongoing.results,
-            reference = reference()
+            reference = reference(),
+            debugInformation = ongoing.debugInformation()
         )
         repeat(iterations) { i ->
             // and processing it
@@ -79,7 +80,8 @@ class RandomUpdateTest(
             }
             builder.add(
                 self = elapsedTime to current,
-                reference = reference()
+                reference = reference(),
+                debugInformation = ongoing.debugInformation()
             )
         }
         builder.build()
@@ -108,6 +110,7 @@ class RandomUpdateTest(
             fun add(
                 self: Pair<Duration, List<Bindings>>,
                 reference: Pair<Duration, List<Bindings>>,
+                debugInformation: String,
             ) {
                 list.add(
                     compare(
@@ -115,7 +118,7 @@ class RandomUpdateTest(
                         elapsedTime = self.first,
                         expected = reference.second,
                         referenceTime = reference.first,
-                        debugInformation = ""
+                        debugInformation = debugInformation
                     )
                 )
             }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
@@ -307,6 +307,10 @@ class MultiHashMappingArray(bindings: Set<String>): MappingArray {
             return Iter(indexes.iterator())
         }
 
+        override fun supportsReuse(): Boolean {
+            return true
+        }
+
     }
 
     private fun IndexStream.toStream(): OptimisedStream<Mapping> = Mapper(indexes, Cardinality(cardinality))

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
@@ -1,10 +1,10 @@
 package dev.tesserakt.sparql.runtime.query
 
-import dev.tesserakt.sparql.types.TriplePattern
-import dev.tesserakt.sparql.types.Union
 import dev.tesserakt.sparql.runtime.collection.MappingArray
 import dev.tesserakt.sparql.runtime.evaluation.*
 import dev.tesserakt.sparql.runtime.stream.*
+import dev.tesserakt.sparql.types.TriplePattern
+import dev.tesserakt.sparql.types.Union
 import dev.tesserakt.sparql.util.Bitmask
 import dev.tesserakt.sparql.util.Cardinality
 import dev.tesserakt.sparql.util.OneCardinality

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/TriplePatternState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/TriplePatternState.kt
@@ -1,13 +1,13 @@
 package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.types.TriplePattern
-import dev.tesserakt.sparql.types.bindingName
-import dev.tesserakt.sparql.types.matches
 import dev.tesserakt.sparql.runtime.RuntimeStatistics
 import dev.tesserakt.sparql.runtime.collection.MappingArray
 import dev.tesserakt.sparql.runtime.evaluation.*
 import dev.tesserakt.sparql.runtime.stream.*
+import dev.tesserakt.sparql.types.TriplePattern
+import dev.tesserakt.sparql.types.bindingName
+import dev.tesserakt.sparql.types.matches
 import dev.tesserakt.sparql.util.Cardinality
 
 sealed class TriplePatternState<P : TriplePattern.Predicate>(
@@ -243,9 +243,8 @@ sealed class TriplePatternState<P : TriplePattern.Predicate>(
     ) : TriplePatternState<TriplePattern.Sequence>(s, p, o) {
 
         private val tree = JoinTree(p.unfold(start = s, end = o))
-        private val mappings = mutableListOf<Mapping>()
         override val cardinality: Cardinality
-            get() = Cardinality(mappings.size)
+            get() = tree.cardinality
 
         override fun process(delta: DataDelta) {
             tree.process(delta)
@@ -270,9 +269,8 @@ sealed class TriplePatternState<P : TriplePattern.Predicate>(
     ) : TriplePatternState<TriplePattern.UnboundSequence>(subj, pred, obj) {
 
         private val tree = JoinTree(pred.unfold(start = subj, end = obj))
-        private val mappings = mutableListOf<Mapping>()
         override val cardinality: Cardinality
-            get() = Cardinality(mappings.size)
+            get() = tree.cardinality
 
         override fun process(delta: DataDelta) {
             tree.process(delta)

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/Util.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/Util.kt
@@ -1,7 +1,5 @@
 package dev.tesserakt.sparql.runtime.query
 
-import dev.tesserakt.sparql.types.TriplePattern
-import dev.tesserakt.sparql.types.bindingName
 import dev.tesserakt.sparql.newAnonymousBinding
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
 import dev.tesserakt.sparql.runtime.evaluation.plus
@@ -9,6 +7,8 @@ import dev.tesserakt.sparql.runtime.stream.OptimisedStream
 import dev.tesserakt.sparql.runtime.stream.Stream
 import dev.tesserakt.sparql.runtime.stream.mappedNonNull
 import dev.tesserakt.sparql.runtime.stream.product
+import dev.tesserakt.sparql.types.TriplePattern
+import dev.tesserakt.sparql.types.bindingName
 import dev.tesserakt.sparql.util.Bitmask
 
 /**
@@ -27,7 +27,7 @@ inline fun List<Pair<Bitmask, List<MappingDelta>>>.expandBindingDeltas(): List<P
                 return@forEach
             }
             // creating all mappings that result from combining these two sub-results
-            val merged = join(current.second, contender.second)
+            val merged = joinLists(current.second, contender.second)
             // if any have been made, its combination can be appended to this result
             if (merged.isNotEmpty()) {
                 result.add(current.first or contender.first to merged)
@@ -39,7 +39,7 @@ inline fun List<Pair<Bitmask, List<MappingDelta>>>.expandBindingDeltas(): List<P
     return result
 }
 
-fun join(a: List<MappingDelta>, b: List<MappingDelta>): List<MappingDelta> =
+fun joinLists(a: List<MappingDelta>, b: List<MappingDelta>): List<MappingDelta> =
     buildList(a.size + b.size) {
         a.forEach { one -> b.forEach { two -> (one + two)?.let { merged -> add(merged) } } }
     }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/BufferedStream.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/BufferedStream.kt
@@ -50,4 +50,8 @@ class BufferedStream<E: Any>(
         return Iter()
     }
 
+    override fun supportsReuse(): Boolean {
+        return true
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/CollectedStream.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/CollectedStream.kt
@@ -11,6 +11,10 @@ value class CollectedStream<E: Any>(private val data: List<E>): Stream<E>, Optim
     override val description: String
         get() = "Collected(size = ${data.size})"
 
+    override fun supportsReuse(): Boolean {
+        return true
+    }
+
     companion object {
 
         operator fun <E: Any> invoke(stream: Stream<E>) = CollectedStream<E>(

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/EmptyStream.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/EmptyStream.kt
@@ -25,4 +25,8 @@ object EmptyStream: Stream<Nothing>, OptimisedStream<Nothing> {
 
     override fun iterator() = Iterator
 
+    override fun supportsReuse(): Boolean {
+        return true
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Extensions.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Extensions.kt
@@ -253,7 +253,7 @@ inline fun <E : Any> Stream<E>.collect(): CollectedStream<E> =
 fun <E : Any> Stream<E>.optimisedForReuse(): OptimisedStream<E> = when {
     hasZeroCardinality() -> emptyStream()
     // we *have* to buffer these, as otherwise reuse is not possible
-    this is SingleUseStreamView<E> -> BufferedStream(this)
+    !supportsReuse() -> BufferedStream(this)
     this is OptimisedStream -> this
     supportsEfficientIteration() -> OptimisedStreamView(this)
     this is StreamChain<E> -> {

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/SingleStream.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/SingleStream.kt
@@ -28,4 +28,8 @@ value class SingleStream<E: Any>(private val element: E): Stream<E>, OptimisedSt
         return Iter(element)
     }
 
+    override fun supportsReuse(): Boolean {
+        return true
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/SingleUseStreamView.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/SingleUseStreamView.kt
@@ -32,4 +32,8 @@ class SingleUseStreamView<E: Any> private constructor(
         return iter ?: throw NoSuchElementException("$sourceDescription has already been consumed!")
     }
 
+    override fun supportsReuse(): Boolean {
+        return false
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Stream.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Stream.kt
@@ -21,4 +21,10 @@ interface Stream<out E: Any>: Iterable<E> {
      */
     fun supportsEfficientIteration(): Boolean
 
+    /**
+     * Analyses this stream's dependencies to detect whether its iteration can be done multiple times, which can be used
+     *  to carefully buffer/collect single use streams when repeated iterations are required.
+     */
+    fun supportsReuse(): Boolean
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamChain.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamChain.kt
@@ -54,4 +54,8 @@ class StreamChain<E: Any>(
         return Iter(source1 = source1.iterator(), source2 = source2.iterator())
     }
 
+    override fun supportsReuse(): Boolean {
+        return source1.supportsReuse() && source2.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamFilter.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamFilter.kt
@@ -69,4 +69,8 @@ class StreamFilter<I: Any>(
         )
     }
 
+    override fun supportsReuse(): Boolean {
+        return source.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMapping.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMapping.kt
@@ -51,4 +51,8 @@ class StreamMapping<I: Any, O: Any>(
         return Iter(source.iterator(), transform)
     }
 
+    override fun supportsReuse(): Boolean {
+        return source.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMappingNullable.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMappingNullable.kt
@@ -65,4 +65,8 @@ class StreamMappingNullable<I: Any, O: Any>(
         )
     }
 
+    override fun supportsReuse(): Boolean {
+        return source.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMultiJoin.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMultiJoin.kt
@@ -90,4 +90,8 @@ class StreamMultiJoin(
         }
     }
 
+    override fun supportsReuse(): Boolean {
+        return left.supportsReuse() && right.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamProduct.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamProduct.kt
@@ -78,4 +78,8 @@ class StreamProduct<A: Any, B: Any>(
         return Iter(a = left, b = right)
     }
 
+    override fun supportsReuse(): Boolean {
+        return left.supportsReuse() && right.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamReduction.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamReduction.kt
@@ -60,4 +60,8 @@ class StreamReduction<E: Any>(
         return Iter(source = source.iterator(), remove = counter.clone())
     }
 
+    override fun supportsReuse(): Boolean {
+        return source.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamSingleJoin.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamSingleJoin.kt
@@ -70,4 +70,8 @@ class StreamSingleJoin(
         return Iter(left = left, source = right.iterator())
     }
 
+    override fun supportsReuse(): Boolean {
+        return right.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamTransform.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamTransform.kt
@@ -61,4 +61,8 @@ class StreamTransform<I: Any, O: Any>(
         )
     }
 
+    override fun supportsReuse(): Boolean {
+        return source.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamTransformNullable.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamTransformNullable.kt
@@ -60,4 +60,8 @@ class StreamTransformNullable<I: Any, O: Any>(
         return if (stream == null) emptyIterator() else Iter(stream, iter, transform)
     }
 
+    override fun supportsReuse(): Boolean {
+        return source.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamWithIndex.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamWithIndex.kt
@@ -46,4 +46,8 @@ value class StreamWithIndex<I : Any>(private val parent: Stream<I>): Stream<Pair
         return Iter(iterator = parent.iterator())
     }
 
+    override fun supportsReuse(): Boolean {
+        return parent.supportsReuse()
+    }
+
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Util.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Util.kt
@@ -35,6 +35,10 @@ inline fun <E: Any> Iterable<E>.toStream(cardinality: Cardinality) = object: Str
         return this@toStream.iterator()
     }
 
+    override fun supportsReuse(): Boolean {
+        return true
+    }
+
 }
 
 inline fun <E: Any> Collection<E>.toStream(): OptimisedStream<E> = when {

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/util/Cardinality.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/util/Cardinality.kt
@@ -1,6 +1,7 @@
 package dev.tesserakt.sparql.util
 
 import kotlin.jvm.JvmInline
+import kotlin.math.roundToLong
 
 @JvmInline
 value class Cardinality(private val value: Double): Comparable<Cardinality> {
@@ -34,5 +35,9 @@ value class Cardinality(private val value: Double): Comparable<Cardinality> {
     fun toInt() = value.toInt()
 
     fun toDouble() = value
+
+    override fun toString(): String {
+        return value.roundToLong().toString()
+    }
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluation.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluation.kt
@@ -53,6 +53,10 @@ class OngoingQueryEvaluation<RT>(private val query: QueryState<RT, *>) {
         ensureValidState()
     }
 
+    fun debugInformation(): String {
+        return processor.debugInformation()
+    }
+
     private fun process(change: QueryState.ResultChange<Bindings>) {
         when (val mapped = query.process(change)) {
             is QueryState.ResultChange.New<*> -> {


### PR DESCRIPTION
Fixes the failing sequence path test, which was caused by the triple pattern state not behaving correctly in the dynamic join tree due to a cardinality bug.
Added a new stream hint `supportsReuse()`, which checks its sources to confirm multiple iterations are possible, ensuring appropriate buffering strategies are used when reuse of a stream is expected.