### PR TITLE
Query evaluation performance fix

### DIFF
--- a/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalReplay.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/tests/IncrementalReplay.kt
@@ -88,7 +88,7 @@ suspend fun compareIncrementalStoreReplay(benchmarkFilepath: String) {
             val received: List<Bindings>
             val time = measureTime {
                 store.apply(diff)
-                received = evaluation.results
+                received = evaluation.results.toList()
             }
             check(store.size == current.size)
             // comparing the results with the reference implementation, using the `current` store version's data

--- a/benchmarking/src/commonMain/kotlin/sparql/types/IncrementalUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/IncrementalUpdateTest.kt
@@ -4,7 +4,7 @@ import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Bindings
 import dev.tesserakt.sparql.OngoingQueryEvaluation
-import dev.tesserakt.sparql.query
+import dev.tesserakt.sparql.queryDebug
 import dev.tesserakt.testing.Test
 import dev.tesserakt.testing.runTest
 import sparql.ExternalQueryExecution
@@ -34,7 +34,7 @@ class IncrementalUpdateTest(
         }
         val ongoing: OngoingQueryEvaluation<Bindings>
         val setupTime= measureTime {
-            ongoing = input.query(query)
+            ongoing = input.queryDebug(query)
         }
         // checking the initial state (no data)
         builder.add(

--- a/benchmarking/src/commonMain/kotlin/sparql/types/IncrementalUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/IncrementalUpdateTest.kt
@@ -38,7 +38,7 @@ class IncrementalUpdateTest(
         }
         // checking the initial state (no data)
         builder.add(
-            self = setupTime to ongoing.results,
+            self = setupTime to ongoing.results.toList(),
             reference = reference(),
             debugInformation = ongoing.debugInformation()
         )
@@ -47,7 +47,7 @@ class IncrementalUpdateTest(
             val current: List<Bindings>
             val elapsedTime = measureTime {
                 input.add(quad)
-                current = ongoing.results
+                current = ongoing.results.toList()
             }
             builder.add(
                 self = elapsedTime to current,
@@ -60,7 +60,7 @@ class IncrementalUpdateTest(
             val current: List<Bindings>
             val elapsedTime = measureTime {
                 input.remove(quad)
-                current = ongoing.results
+                current = ongoing.results.toList()
             }
             builder.add(
                 self = elapsedTime to current,

--- a/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
@@ -59,7 +59,7 @@ class RandomUpdateTest(
         }
         // checking the initial state (no data)
         builder.add(
-            self = setupTime to ongoing.results,
+            self = setupTime to ongoing.results.toList(),
             reference = reference(),
             debugInformation = ongoing.debugInformation()
         )
@@ -69,7 +69,7 @@ class RandomUpdateTest(
             val elapsedTime = measureTime {
                 try {
                     input.process(deltas[i])
-                    current = ongoing.results
+                    current = ongoing.results.toList()
                 } catch (e: Exception) {
                     val results = builder.build()
                     throw RuntimeException(

--- a/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/RandomUpdateTest.kt
@@ -6,7 +6,7 @@ import dev.tesserakt.rdf.types.Store
 import dev.tesserakt.sparql.Bindings
 import dev.tesserakt.sparql.OngoingQueryEvaluation
 import dev.tesserakt.sparql.Query
-import dev.tesserakt.sparql.query
+import dev.tesserakt.sparql.queryDebug
 import dev.tesserakt.sparql.runtime.evaluation.DataAddition
 import dev.tesserakt.sparql.runtime.evaluation.DataDeletion
 import dev.tesserakt.sparql.runtime.evaluation.DataDelta
@@ -55,7 +55,7 @@ class RandomUpdateTest(
 
         val ongoing: OngoingQueryEvaluation<Bindings>
         val setupTime = measureTime {
-            ongoing = input.query(query)
+            ongoing = input.queryDebug(query)
         }
         // checking the initial state (no data)
         builder.add(

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/Extensions.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/Extensions.kt
@@ -62,6 +62,10 @@ fun <RT> MutableStore.query(query: Query<RT>): OngoingQueryEvaluation<RT> {
     return OngoingQueryEvaluationRelease(query.createState()).also { it.subscribe(this) }
 }
 
+fun <RT> MutableStore.queryDebug(query: Query<RT>): OngoingQueryEvaluation<RT> {
+    return OngoingQueryEvaluationDebug(query.createState()).also { it.subscribe(this) }
+}
+
 internal fun <RT> MutableStore.query(query: QueryState<RT, *>): OngoingQueryEvaluation<RT> {
     return OngoingQueryEvaluationRelease(query).also { it.subscribe(this) }
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/Extensions.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/Extensions.kt
@@ -59,9 +59,9 @@ internal fun <RT> Iterable<Quad>.query(query: QueryState<RT, *>): List<RT> = bui
 }
 
 fun <RT> MutableStore.query(query: Query<RT>): OngoingQueryEvaluation<RT> {
-    return OngoingQueryEvaluation(query.createState()).also { it.subscribe(this) }
+    return OngoingQueryEvaluationRelease(query.createState()).also { it.subscribe(this) }
 }
 
 internal fun <RT> MutableStore.query(query: QueryState<RT, *>): OngoingQueryEvaluation<RT> {
-    return OngoingQueryEvaluation(query).also { it.subscribe(this) }
+    return OngoingQueryEvaluationRelease(query).also { it.subscribe(this) }
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluation.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluation.kt
@@ -2,76 +2,19 @@ package dev.tesserakt.sparql
 
 import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.runtime.evaluation.DataAddition
-import dev.tesserakt.sparql.runtime.evaluation.DataDeletion
-import dev.tesserakt.sparql.runtime.query.QueryState
-import dev.tesserakt.util.replace
 
+interface OngoingQueryEvaluation<RT> {
 
-class OngoingQueryEvaluation<RT>(private val query: QueryState<RT, *>) {
+    val results: Collection<RT>
 
-    private val _results = mutableMapOf<RT, Int>()
-    val results get() = _results.flatMap { entry -> List(entry.value) { entry.key } }
+    fun subscribe(store: MutableStore)
 
-    private val processor = query.Processor()
+    fun unsubscribe(store: MutableStore)
 
-    private val listener = object: MutableStore.Listener {
-        override fun onQuadAdded(quad: Quad) {
-            add(quad)
-        }
+    fun add(quad: Quad)
 
-        override fun onQuadRemoved(quad: Quad) {
-            remove(quad)
-        }
-    }
+    fun remove(quad: Quad)
 
-    init {
-        // setting the query state as the current results
-        processor.state().forEach {
-            _results[it] = 1
-        }
-    }
-
-    fun subscribe(store: MutableStore) {
-        store.forEach { quad ->
-            processor.process(DataAddition(quad)).forEach { process(it) }
-        }
-        store.addListener(listener)
-    }
-
-    fun unsubscribe(store: MutableStore) {
-        store.removeListener(listener)
-    }
-
-    fun add(quad: Quad) {
-        processor.process(DataAddition(quad)).forEach { process(it) }
-        ensureValidState()
-    }
-
-    fun remove(quad: Quad) {
-        processor.process(DataDeletion(quad)).forEach { process(it) }
-        ensureValidState()
-    }
-
-    fun debugInformation(): String {
-        return processor.debugInformation()
-    }
-
-    private fun process(change: QueryState.ResultChange<Bindings>) {
-        when (val mapped = query.process(change)) {
-            is QueryState.ResultChange.New<*> -> {
-                _results.replace(mapped.value) { current -> (current ?: 0) + 1 }
-            }
-            is QueryState.ResultChange.Removed<*> -> {
-                _results.replace(mapped.value) { current -> (current ?: 0) - 1 }
-            }
-        }
-    }
-
-    private fun ensureValidState() {
-        _results.forEach {
-            check(it.value >= 0) { "${it.key} was not removed properly from the result list as it did not exist!" }
-        }
-    }
+    fun debugInformation(): String
 
 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationDebug.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationDebug.kt
@@ -1,0 +1,77 @@
+package dev.tesserakt.sparql
+
+import dev.tesserakt.rdf.types.MutableStore
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.DataAddition
+import dev.tesserakt.sparql.runtime.evaluation.DataDeletion
+import dev.tesserakt.sparql.runtime.query.QueryState
+import dev.tesserakt.util.replace
+
+
+class OngoingQueryEvaluationDebug<RT>(private val query: QueryState<RT, *>): OngoingQueryEvaluation<RT> {
+
+    private val _results = mutableMapOf<RT, Int>()
+    override val results get() = _results.flatMap { entry -> List(entry.value) { entry.key } }
+
+    private val processor = query.Processor()
+
+    private val listener = object: MutableStore.Listener {
+        override fun onQuadAdded(quad: Quad) {
+            add(quad)
+        }
+
+        override fun onQuadRemoved(quad: Quad) {
+            remove(quad)
+        }
+    }
+
+    init {
+        // setting the query state as the current results
+        processor.state().forEach {
+            _results[it] = 1
+        }
+    }
+
+    override fun subscribe(store: MutableStore) {
+        store.forEach { quad ->
+            processor.process(DataAddition(quad)).forEach { process(it) }
+        }
+        store.addListener(listener)
+    }
+
+    override fun unsubscribe(store: MutableStore) {
+        store.removeListener(listener)
+    }
+
+    override fun add(quad: Quad) {
+        processor.process(DataAddition(quad)).forEach { process(it) }
+        ensureValidState()
+    }
+
+    override fun remove(quad: Quad) {
+        processor.process(DataDeletion(quad)).forEach { process(it) }
+        ensureValidState()
+    }
+
+    override fun debugInformation(): String {
+        return processor.debugInformation()
+    }
+
+    private fun process(change: QueryState.ResultChange<Bindings>) {
+        when (val mapped = query.process(change)) {
+            is QueryState.ResultChange.New<*> -> {
+                _results.replace(mapped.value) { current -> (current ?: 0) + 1 }
+            }
+            is QueryState.ResultChange.Removed<*> -> {
+                _results.replace(mapped.value) { current -> (current ?: 0) - 1 }
+            }
+        }
+    }
+
+    private fun ensureValidState() {
+        _results.forEach {
+            check(it.value >= 0) { "${it.key} was not removed properly from the result list as it did not exist!" }
+        }
+    }
+
+}

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationRelease.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationRelease.kt
@@ -1,0 +1,69 @@
+package dev.tesserakt.sparql
+
+import dev.tesserakt.rdf.types.MutableStore
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.DataAddition
+import dev.tesserakt.sparql.runtime.evaluation.DataDeletion
+import dev.tesserakt.sparql.runtime.query.QueryState
+import dev.tesserakt.util.replace
+
+
+class OngoingQueryEvaluationRelease<RT>(private val query: QueryState<RT, *>): OngoingQueryEvaluation<RT> {
+
+    private val _results = mutableMapOf<RT, Int>()
+    override val results get() = _results.flatMap { entry -> List(entry.value) { entry.key } }
+
+    private val processor = query.Processor()
+
+    private val listener = object: MutableStore.Listener {
+        override fun onQuadAdded(quad: Quad) {
+            add(quad)
+        }
+
+        override fun onQuadRemoved(quad: Quad) {
+            remove(quad)
+        }
+    }
+
+    init {
+        // setting the query state as the current results
+        processor.state().forEach {
+            _results[it] = 1
+        }
+    }
+
+    override fun subscribe(store: MutableStore) {
+        store.forEach { quad ->
+            processor.process(DataAddition(quad)).forEach { process(it) }
+        }
+        store.addListener(listener)
+    }
+
+    override fun unsubscribe(store: MutableStore) {
+        store.removeListener(listener)
+    }
+
+    override fun add(quad: Quad) {
+        processor.process(DataAddition(quad)).forEach { process(it) }
+    }
+
+    override fun remove(quad: Quad) {
+        processor.process(DataDeletion(quad)).forEach { process(it) }
+    }
+
+    override fun debugInformation(): String {
+        return processor.debugInformation()
+    }
+
+    private fun process(change: QueryState.ResultChange<Bindings>) {
+        when (val mapped = query.process(change)) {
+            is QueryState.ResultChange.New<*> -> {
+                _results.replace(mapped.value) { current -> (current ?: 0) + 1 }
+            }
+            is QueryState.ResultChange.Removed<*> -> {
+                _results.replace(mapped.value) { current -> (current ?: 0) - 1 }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The filter implementation changed how query execution correctness is evaluated, negatively impacting performance when the number of bindings and changes are substantial due to the # of additional iterations done. This MR removes this check in a new "release" implementation of the ongoing query evaluation type, as this evaluation is only required to guarantee correctness during development, and should be avoided during benchmarking anyway. A new `MutableStore.queryDebug()` method having the original behaviour is now available, whilst the original `MutableStore.query()` drops this potentially expensive check.