### PR TITLE
Mapping rework, query context and benchmarking improvements

### DIFF
--- a/benchmarking/microbench/build.gradle.kts
+++ b/benchmarking/microbench/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    kotlin("multiplatform")
+    id("org.jetbrains.kotlinx.benchmark") version "0.4.13"
+    kotlin("plugin.allopen") version "2.0.20"
+}
+
+kotlin {
+    jvm()
+    js {
+        nodejs()
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(project(":common"))
+                implementation(project(":rdf"))
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.13")
+
+                // also adding types from the runtime we want to benchmark
+                implementation(project(":sparql:runtime"))
+            }
+        }
+    }
+}
+
+benchmark {
+    targets {
+        register("jvm")
+        register("js")
+    }
+}
+
+allOpen {
+    annotation("org.openjdk.jmh.annotations.State")
+}

--- a/benchmarking/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
+++ b/benchmarking/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
@@ -3,6 +3,7 @@ package dev.tesserakt
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
+import dev.tesserakt.sparql.runtime.evaluation.GlobalQueryContext
 import dev.tesserakt.sparql.runtime.evaluation.Mapping
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.Scope
@@ -45,6 +46,7 @@ class MappingBenchmark {
     private val right = mutableListOf<MapMapping>()
     private lateinit var l: List<Mapping>
     private lateinit var r: List<Mapping>
+    private val context = GlobalQueryContext
 
     @Setup
     fun createMappings() {
@@ -57,8 +59,8 @@ class MappingBenchmark {
                 right.add(new)
             }
         }
-        l = left.map { Mapping(it) }
-        r = right.map { Mapping(it) }
+        l = left.map { Mapping(context, it) }
+        r = right.map { Mapping(context, it) }
     }
 
     @Benchmark

--- a/benchmarking/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
+++ b/benchmarking/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
@@ -1,0 +1,76 @@
+package dev.tesserakt
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
+import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
+import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlin.random.Random
+
+const val SIZE = 7_500
+const val VARIANCE = 50
+val BINDINGS = listOf(
+    "person" to List(VARIANCE) { "http://example/person_${it}".asNamedTerm() },
+    "job" to List(VARIANCE) { "http://example/job_${it}".asNamedTerm() },
+    "name" to List(VARIANCE) { "http://example/name_${it}".asNamedTerm() },
+    "age" to List(VARIANCE) { it.asLiteralTerm() },
+)
+
+typealias MapMapping = Map<String, Quad.Term>
+
+private fun createMapping(id: Int): MapMapping {
+    val rng = Random(id)
+    return BINDINGS.associate { it.first to it.second.random(rng) }.filter { rng.nextBoolean() }
+}
+
+private inline fun <K: Any, V: Any> Map<K, V>.compatibleWith(reference: Map<K, V>) =
+    reference.all { (refKey, refValue) -> val data = this[refKey]; data == null || data == refValue}
+
+
+private fun join(a: MapMapping, b: MapMapping): MapMapping? {
+    return if (a.compatibleWith(b)) {
+        a + b
+    } else {
+        null
+    }
+}
+
+@State(Scope.Benchmark)
+class MappingBenchmark {
+
+    private val left = mutableListOf<MapMapping>()
+    private val right = mutableListOf<MapMapping>()
+    private lateinit var l: List<Mapping>
+    private lateinit var r: List<Mapping>
+
+    @Setup
+    fun createMappings() {
+        val random = Random(1)
+        repeat(SIZE) {
+            val new = createMapping(random.nextInt())
+            if (random.nextBoolean()) {
+                left.add(new)
+            } else {
+                right.add(new)
+            }
+        }
+        l = left.map { Mapping(it) }
+        r = right.map { Mapping(it) }
+    }
+
+    @Benchmark
+    fun joinRegular(): List<MapMapping> {
+        return left.flatMap { l -> right.mapNotNull { r -> join(l, r) } }
+            .also { println("Result size regular: ${it.size}") }
+    }
+
+    @Benchmark
+    fun joinNew(): List<Mapping> {
+        return l.flatMap { l -> r.mapNotNull { r -> l.join(r) } }
+            .also { println("Result size new: ${it.size}") }
+    }
+
+}

--- a/benchmarking/runner/build.gradle.kts
+++ b/benchmarking/runner/build.gradle.kts
@@ -49,6 +49,7 @@ val cleanBenchmarkResults = tasks.register("cleanBenchmarkResults", Exec::class.
 }
 
 val graphPreparation = tasks.register("prepareGraphingTool", Exec::class.java) {
+    group = "benchmarking"
     enabled = !graphingTarget.get().asFile.exists()
     workingDir = build.asFile.get()
     val url = local("benchmarking.graph.url")
@@ -57,12 +58,14 @@ val graphPreparation = tasks.register("prepareGraphingTool", Exec::class.java) {
 }
 
 val graphConfiguration = tasks.register("configureGraphingTool", Exec::class.java) {
+    group = "benchmarking"
     enabled = !graphingTarget.get().file("pyvenv.cfg").asFile.exists()
     workingDir = build.asFile.get()
     commandLine("python", "-m", "venv", "graphs")
 }
 
 val graphInstallation = tasks.register("installGraphingTool", Exec::class.java) {
+    group = "benchmarking"
     enabled = !graphingTarget.get().dir("lib").asFile.listFiles()?.singleOrNull { it.isDirectory }?.listFiles()
         ?.singleOrNull { it.name == "site-packages" }?.listFiles()
         .let { it != null && it.any { it.isDirectory && it.name == "pandas" } }
@@ -71,15 +74,16 @@ val graphInstallation = tasks.register("installGraphingTool", Exec::class.java) 
 }
 
 val runner = tasks.register("runBenchmark", Exec::class) {
+    group = "benchmarking"
     workingDir = build.asFile.get()
-    val jar = build.dir("libs").get().asFile.listFiles()?.singleOrNull { it.extension == "jar" }?.path
-    check(jar != null) { "Could not resolve the executable JAR file!" }
+    val jar = build.dir("libs").get().file("runner-jvm-${version}.jar").asFile.path
     val source = local("benchmarking.input")
         ?: throw IllegalStateException("No benchmark input configured! Please add `benchmarking.input=<path/to/dataset>` to `${project.rootProject.rootDir.path}/local.properties`!")
     commandLine("java", "-jar", jar, "-i", source, "-o", "${build.get().asFile.path}/benchmark_output/", "--compare-implementations")
 }
 
 val graphing = tasks.register("createBenchmarkGraphs", Exec::class.java) {
+    group = "benchmarking"
     val targets = build.dir("benchmark_output").get().asFile.path + "/*"
     workingDir = graphingTarget.get().asFile
     commandLine("./bin/python", "main.py", targets)

--- a/benchmarking/runner/src/commonMain/kotlin/dev/tesserakt/benchmarking/Util.kt
+++ b/benchmarking/runner/src/commonMain/kotlin/dev/tesserakt/benchmarking/Util.kt
@@ -8,7 +8,7 @@ expect fun currentEpochMs(): Long
  * Compares results from the first set [a] with the second set [b], where [a] represents the most up-to-date version
  *  of the result that is being compared
  */
-fun compare(a: List<Any>, b: List<Any>): Evaluator.Output {
+fun compare(a: List<Any>, b: List<Any>, checksum: Int): Evaluator.Output {
     val counts = a.groupingBy { it }.eachCount().toMutableMap()
     b.forEach {
         counts.replace(it) { v -> (v ?: 0) - 1 }
@@ -16,6 +16,7 @@ fun compare(a: List<Any>, b: List<Any>): Evaluator.Output {
     return Evaluator.Output(
         added = counts.filter { it.value > 0 }.entries.sumOf { entry -> entry.value },
         removed = counts.filter { it.value < 0 }.entries.sumOf { entry -> -entry.value },
+        checksum = checksum,
     )
 }
 

--- a/benchmarking/runner/src/jvmMain/kotlin/dev/tesserakt/benchmarking/Evaluator.jvm.kt
+++ b/benchmarking/runner/src/jvmMain/kotlin/dev/tesserakt/benchmarking/Evaluator.jvm.kt
@@ -2,6 +2,9 @@ package dev.tesserakt.benchmarking
 
 import dev.tesserakt.interop.jena.toJenaQuad
 import dev.tesserakt.sparql.benchmark.replay.SnapshotStore
+import org.apache.jena.graph.Node_Blank
+import org.apache.jena.graph.Node_Literal
+import org.apache.jena.graph.Node_URI
 import org.apache.jena.query.DatasetFactory
 import org.apache.jena.query.QueryExecutionFactory
 import org.apache.jena.query.QuerySolution
@@ -12,6 +15,8 @@ actual class Reference actual constructor(private val query: String) : Evaluator
     private val store = DatasetFactory.createTxnMem()
     private var previous = emptyList<QuerySolution>()
     private var current = emptyList<QuerySolution>()
+
+    private var checksum = 0
 
     override fun prepare(diff: SnapshotStore.Diff) {
         store.begin(ReadWrite.WRITE)
@@ -31,14 +36,24 @@ actual class Reference actual constructor(private val query: String) : Evaluator
             val solutions = execution.execSelect()
             // consuming the solution
             while (solutions.hasNext()) {
-                results.add(solutions.next())
+                val solution = solutions.next()
+                results.add(solution)
+                solution.varNames().forEach {
+                    checksum += when (val variable = solution[it].asNode()) {
+                        is Node_URI -> variable.uri.length
+                        is Node_Literal -> variable.literalValue.toString().length
+                        is Node_Blank -> variable.blankNodeLabel.length
+                        else -> throw IllegalArgumentException("Unknown node type `${this::class.simpleName}`")
+                    }
+                }
             }
             current = results
         }
     }
 
     override fun finish(): Output {
-        val result = compare(current, previous)
+        val result = compare(current, previous, checksum = checksum)
+        checksum = 0
         previous = current
         return result
     }

--- a/benchmarking/runner/src/jvmMain/kotlin/dev/tesserakt/benchmarking/OutputObserver.kt
+++ b/benchmarking/runner/src/jvmMain/kotlin/dev/tesserakt/benchmarking/OutputObserver.kt
@@ -8,11 +8,11 @@ class OutputObserver(filepath: String) {
     private val writer = BufferedWriter(FileWriter(filepath))
 
     init {
-        writer.write("name,additions,removals\n")
+        writer.write("name,additions,removals,checksum\n")
     }
 
     fun markResult(id: String, output: Evaluator.Output) {
-        writer.write("$id,${output.added},${output.removed}\n")
+        writer.write("$id,${output.added},${output.removed},${output.checksum}\n")
     }
 
     fun stop() {

--- a/benchmarking/src/commonMain/kotlin/sparql/types/Comparison.kt
+++ b/benchmarking/src/commonMain/kotlin/sparql/types/Comparison.kt
@@ -1,6 +1,7 @@
 package sparql.types
 
 import dev.tesserakt.sparql.Bindings
+import dev.tesserakt.sparql.toBindings
 import dev.tesserakt.util.replace
 
 
@@ -15,15 +16,17 @@ fun fastCompare(
     a: List<Bindings>,
     b: List<Bindings>
 ): ComparisonResult {
-    val counts = a.groupingBy { it }.eachCount().toMutableMap()
-    b.forEach {
+    val stable1 = a.map { it.sortedBy { it.first } }
+    val stable2 = b.map { it.sortedBy { it.first } }
+    val counts = stable1.groupingBy { it }.eachCount().toMutableMap()
+    stable2.forEach {
         counts.replace(it) { v -> (v ?: 0) - 1 }
     }
     if (counts.all { it.value == 0 }) {
         return ExactMatch
     }
     return ComparisonResult(
-        missing = counts.filter { it.value > 0 }.flatMap { entry -> List(entry.value) { entry.key } },
-        leftOver = counts.filter { it.value < 0 }.flatMap { entry -> List(-entry.value) { entry.key } },
+        missing = counts.filter { it.value > 0 }.flatMap { entry -> List(entry.value) { entry.key.toBindings() } },
+        leftOver = counts.filter { it.value < 0 }.flatMap { entry -> List(-entry.value) { entry.key.toBindings() } },
     )
 }

--- a/benchmarking/src/jvmMain/kotlin/sparql/Util.kt
+++ b/benchmarking/src/jvmMain/kotlin/sparql/Util.kt
@@ -4,6 +4,7 @@ import dev.tesserakt.interop.jena.toJenaDataset
 import dev.tesserakt.interop.jena.toTerm
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.Bindings
+import dev.tesserakt.sparql.toBindings
 import org.apache.jena.query.Dataset
 import org.apache.jena.query.QueryExecutionFactory
 import kotlin.io.path.Path
@@ -30,7 +31,7 @@ actual class ExternalQueryExecution actual constructor(
                 solution.varNames().forEach { name ->
                     solution[name]?.asNode()?.toTerm()?.let { current[name] = it }
                 }
-                results.add(current)
+                results.add(current.toBindings())
             }
         }
         return results

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include("testing:rdf-test-suite-js")
 
 include("benchmarking")
 include("benchmarking:store-replay")
+include("benchmarking:microbench")
 include("benchmarking:runner")
 
 include("js-build")

--- a/sparql/common/src/commonMain/kotlin/dev/tesserakt/sparql/Adapter.kt
+++ b/sparql/common/src/commonMain/kotlin/dev/tesserakt/sparql/Adapter.kt
@@ -1,0 +1,17 @@
+package dev.tesserakt.sparql
+
+import dev.tesserakt.rdf.types.Quad
+import kotlin.jvm.JvmInline
+
+@JvmInline
+private value class BindingsAdapter(val inner: List<Pair<String, Quad.Term>>): Bindings {
+
+    override fun iterator(): Iterator<Pair<String, Quad.Term>> = inner.iterator()
+
+    override fun toString() = joinToString(prefix = "{", postfix = "}") { "${it.first} = ${it.second}" }
+
+}
+
+fun Map<String, Quad.Term>.toBindings(): Bindings = BindingsAdapter(map { it.toPair() })
+
+fun List<Pair<String, Quad.Term>>.toBindings(): Bindings = BindingsAdapter(distinct())

--- a/sparql/common/src/commonMain/kotlin/dev/tesserakt/sparql/Bindings.kt
+++ b/sparql/common/src/commonMain/kotlin/dev/tesserakt/sparql/Bindings.kt
@@ -2,4 +2,4 @@ package dev.tesserakt.sparql
 
 import dev.tesserakt.rdf.types.Quad
 
-typealias Bindings = Map<String, Quad.Term>
+interface Bindings: Iterable<Pair<String, Quad.Term>>

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql.runtime.collection
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.QueryContext
 import dev.tesserakt.sparql.runtime.stream.OptimisedStream
 import dev.tesserakt.sparql.runtime.stream.emptyIterable
 import dev.tesserakt.sparql.util.Cardinality
@@ -10,8 +11,10 @@ import dev.tesserakt.sparql.util.Cardinality
  * An array useful for storing a series of mappings, capable of joining with other mappings using the hash join
  *  algorithm. Hash tables are created for every binding name passed in the constructor.
  */
-class MultiHashMappingArray(bindings: Set<String>): MappingArray {
-
+class MultiHashMappingArray(
+    private val context: QueryContext,
+    bindings: Set<String>
+): MappingArray {
     // the backing structure, contains all mappings ever received
     private val backing = mutableListOf<Mapping?>()
     // the number of holes in the backing structure, indicative of the
@@ -66,7 +69,7 @@ class MultiHashMappingArray(bindings: Set<String>): MappingArray {
         val pos = backing.size
         backing.add(mapping)
         index.forEach { index ->
-            val value = mapping[index.key]
+            val value = mapping.get(context, index.key)
                 ?: throw IllegalArgumentException("Mapping $mapping has no value required for index `${index.key}`")
             index.value
                 .getOrPut(value) { arrayListOf() }
@@ -88,7 +91,7 @@ class MultiHashMappingArray(bindings: Set<String>): MappingArray {
             val mapping = iter.next()
             backing.add(mapping)
             index.forEach { index ->
-                val value = mapping[index.key]
+                val value = mapping.get(context, index.key)
                     ?: throw IllegalArgumentException("Mapping $mapping has no value required for index `${index.key}`")
                 index.value
                     .getOrPut(value) { arrayListOf() }
@@ -180,7 +183,7 @@ class MultiHashMappingArray(bindings: Set<String>): MappingArray {
         @Suppress("UNCHECKED_CAST")
         (backing as List<Mapping>).forEachIndexed { i, mapping ->
             index.forEach { index ->
-                val value = mapping[index.key]
+                val value = mapping.get(context, index.key)
                     ?: throw IllegalArgumentException("Mapping $mapping has no value required for index `${index.key}`")
                 index.value
                     .getOrPut(value) { arrayListOf() }
@@ -211,7 +214,7 @@ class MultiHashMappingArray(bindings: Set<String>): MappingArray {
      * Returns an iterable set of indices compatible with the provided mapping
      */
     private fun indexStreamFor(reference: Mapping): IndexStream {
-        val constraints = reference.retain(index.keys)
+        val constraints = reference.retain(context, index.keys)
         // if there aren't any constraints, all mappings (the entire backing array) can be returned instead
         if (constraints.isEmpty()) {
             return IndexStream(indexes = backing.indices, cardinality = backing.size - holes)
@@ -219,7 +222,7 @@ class MultiHashMappingArray(bindings: Set<String>): MappingArray {
         // getting all relevant indexes - if any of the mapping's values don't have an ID list present for the reference's
         //  value, we can bail early: none match the reference
         val indexes = constraints
-            .asIterable()
+            .asIterable(context)
             .map { binding -> index[binding.first]!![binding.second] ?: return IndexStream.NONE }
         // the resulting array cannot be longer than the smallest index found, so if any of them are empty, no results
         //  are found
@@ -247,7 +250,7 @@ class MultiHashMappingArray(bindings: Set<String>): MappingArray {
         // separating the individual references into their constraints
         val constraints: Map<Mapping?, List<Int>> = references.indices.groupBy { i ->
             val current = references[i] ?: return@groupBy null
-            current.retain(index.keys)
+            current.retain(context, index.keys)
         }
         // with all relevant & unique constraints formed, the compatible mappings w/o redundant lookup can be retrieved
         val mapped = constraints.map { (constraints, indexes) -> (constraints?.let { indexStreamFor(constraints) } ?: IndexStream.NONE) to indexes }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/Util.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/Util.kt
@@ -1,11 +1,13 @@
 package dev.tesserakt.sparql.runtime.collection
 
-fun MappingArray(bindings: Collection<String>) = when {
-    bindings.isNotEmpty() -> MultiHashMappingArray(bindings = bindings.toSet())
+import dev.tesserakt.sparql.runtime.evaluation.QueryContext
+
+fun MappingArray(context: QueryContext, bindings: Collection<String>) = when {
+    bindings.isNotEmpty() -> MultiHashMappingArray(context, bindings = bindings.toSet())
     else -> SimpleMappingArray()
 }
 
-fun MappingArray(vararg bindings: String?): MappingArray {
+fun MappingArray(context: QueryContext, vararg bindings: String?): MappingArray {
     val set = setOfNotNull(*bindings)
-    return MappingArray(set)
+    return MappingArray(context, set)
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifier.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifier.kt
@@ -1,0 +1,14 @@
+package dev.tesserakt.sparql.runtime.evaluation
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class BindingIdentifier(val id: Int) {
+
+    constructor(context: QueryContext, name: String): this(id = context.resolveBinding(name))
+
+    companion object {
+        fun QueryContext.get(binding: BindingIdentifier): String = resolveBinding(id = binding.id)
+    }
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifierSet.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifierSet.kt
@@ -1,16 +1,30 @@
 package dev.tesserakt.sparql.runtime.evaluation
 
+import kotlin.jvm.JvmInline
+
 // not a value class as we have a custom equals check based on the contents of the `IntArray`, instead of reference equality
-class BindingIdentifierSet(private val ids: IntArray): Iterable<Int> {
+class BindingIdentifierSet(private val ids: IntArray) {
 
     constructor(context: QueryContext, names: Iterable<String>) :
             this(ids = names.distinct().map { context.resolveBinding(it) }.sorted().toIntArray())
 
+    @JvmInline
+    value class IdIterator(private val iterator: IntIterator): Iterator<BindingIdentifier> {
+        override fun hasNext() = iterator.hasNext()
+        override fun next() = BindingIdentifier(iterator.next())
+    }
+
     val size: Int
         get() = ids.size
 
-    override fun iterator(): IntIterator {
-        return ids.iterator()
+    fun asIntIterable() = object: Iterable<Int> {
+        override fun iterator(): IntIterator {
+            return ids.iterator()
+        }
+    }
+
+    fun asIdIterable() = object: Iterable<BindingIdentifier> {
+        override fun iterator() = IdIterator(ids.iterator())
     }
 
     operator fun contains(element: Int): Boolean {

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifierSet.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifierSet.kt
@@ -1,0 +1,46 @@
+package dev.tesserakt.sparql.runtime.evaluation
+
+// not a value class as we have a custom equals check based on the contents of the `IntArray`, instead of reference equality
+class BindingIdentifierSet(private val ids: IntArray): Iterable<Int> {
+
+    constructor(context: QueryContext, names: Iterable<String>) :
+            this(ids = names.distinct().map { context.resolveBinding(it) }.sorted().toIntArray())
+
+    val size: Int
+        get() = ids.size
+
+    override fun iterator(): IntIterator {
+        return ids.iterator()
+    }
+
+    operator fun contains(element: Int): Boolean {
+        // we can bin search, elements are sorted
+        var min = 0
+        var max = size - 1
+        while (min <= max) {
+            val mid = min + (max - min) / 2
+            val current = ids[mid]
+            when {
+                element == current -> return true
+                element < current -> max = mid - 1
+                current < element -> min = mid + 1
+            }
+        }
+        return false
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is BindingIdentifierSet) {
+            return false
+        }
+        if (this.size != other.size) {
+            return false
+        }
+        return ids.contentEquals(other.ids)
+    }
+
+    override fun hashCode(): Int {
+        return ids.contentHashCode()
+    }
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
@@ -1,0 +1,27 @@
+package dev.tesserakt.sparql.runtime.evaluation
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.Bindings
+
+class BindingsImpl(private val mapping: Mapping): Bindings {
+
+    private val iterable = mapping.asIterable()
+
+    override fun iterator(): Iterator<Pair<String, Quad.Term>> = iterable.iterator()
+
+    fun retain(names: Set<String>) = BindingsImpl(mapping = mapping.retain(names))
+
+    override fun hashCode(): Int {
+        return mapping.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is BindingsImpl) {
+            return false
+        }
+        return mapping == other.mapping
+    }
+
+    override fun toString() = iterable.joinToString(prefix = "{", postfix = "}") { "${it.first} = ${it.second}" }
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
@@ -3,13 +3,13 @@ package dev.tesserakt.sparql.runtime.evaluation
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.Bindings
 
-class BindingsImpl(private val mapping: Mapping): Bindings {
+class BindingsImpl(private val context: QueryContext, private val mapping: Mapping): Bindings {
 
-    private val iterable = mapping.asIterable()
+    private val iterable = mapping.asIterable(context)
 
     override fun iterator(): Iterator<Pair<String, Quad.Term>> = iterable.iterator()
 
-    fun retain(names: Set<String>) = BindingsImpl(mapping = mapping.retain(names))
+    fun retain(names: Set<String>) = BindingsImpl(context, mapping = mapping.retain(context, names))
 
     override fun hashCode(): Int {
         return mapping.hashCode()

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
@@ -9,7 +9,7 @@ class BindingsImpl(private val context: QueryContext, private val mapping: Mappi
 
     override fun iterator(): Iterator<Pair<String, Quad.Term>> = iterable.iterator()
 
-    fun retain(names: Set<String>) = BindingsImpl(context, mapping = mapping.retain(context, names))
+    fun retain(names: Set<String>) = BindingsImpl(context, mapping = mapping.retain(BindingIdentifierSet(context, names)))
 
     override fun hashCode(): Int {
         return mapping.hashCode()

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/GlobalQueryContext.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/GlobalQueryContext.kt
@@ -1,0 +1,38 @@
+package dev.tesserakt.sparql.runtime.evaluation
+
+import dev.tesserakt.rdf.types.Quad
+
+object GlobalQueryContext: QueryContext {
+
+    private val bindings = mutableListOf<String>()
+    private val bindingsLut = mutableMapOf<String, Int>()
+
+    private val terms = mutableMapOf<Quad.Term, Int>()
+    private val termsLut = mutableMapOf<Int, Quad.Term>()
+
+    override fun resolveBinding(value: String): Int {
+        return bindingsLut.getOrPut(value) {
+            val i = bindings.size
+            require(bindingsLut.size == i)
+            bindings.add(value)
+            i
+        }
+    }
+
+    override fun resolveTerm(value: Quad.Term): Int {
+        return terms.getOrPut(value) {
+            val i = terms.size
+            termsLut[i] = value
+            i
+        }
+    }
+
+    override fun resolveBinding(id: Int): String {
+        return bindings[id]
+    }
+
+    override fun resolveTerm(id: Int): Quad.Term {
+        return termsLut[id]!!
+    }
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/GlobalQueryContext.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/GlobalQueryContext.kt
@@ -8,7 +8,9 @@ object GlobalQueryContext: QueryContext {
     private val bindingsLut = mutableMapOf<String, Int>()
 
     private val terms = mutableMapOf<Quad.Term, Int>()
-    private val termsLut = mutableMapOf<Int, Quad.Term>()
+    // as terms are never removed from an active context, we can keep it as a regular list without risking IDs
+    // shifting over
+    private val termsLut = mutableListOf<Quad.Term>()
 
     override fun resolveBinding(value: String): Int {
         return bindingsLut.getOrPut(value) {
@@ -22,7 +24,7 @@ object GlobalQueryContext: QueryContext {
     override fun resolveTerm(value: Quad.Term): Int {
         return terms.getOrPut(value) {
             val i = terms.size
-            termsLut[i] = value
+            termsLut.add(value)
             i
         }
     }
@@ -32,7 +34,7 @@ object GlobalQueryContext: QueryContext {
     }
 
     override fun resolveTerm(id: Int): Quad.Term {
-        return termsLut[id]!!
+        return termsLut[id]
     }
 
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Mapping.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Mapping.kt
@@ -1,42 +1,338 @@
 package dev.tesserakt.sparql.runtime.evaluation
 
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.Bindings
+import dev.tesserakt.util.isNullOr
+import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmName
 
-class Mapping(private val inner: Map<String, Quad.Term>): Map<String, Quad.Term> by inner {
-    // caching this thing, guaranteed to be static
-    private val hash = inner.hashCode()
+@JvmInline
+value class Mapping private constructor(private val data: IntIntPair?) {
 
-    val bindings: Bindings get() = inner
+    constructor(source: Map<String, Quad.Term>): this(data = convert(source))
 
-    override fun hashCode() = hash
+    constructor(source: Iterable<Pair<String, Quad.Term>>): this(data = convert(source))
 
-    override fun equals(other: Any?): Boolean = other is Mapping && hash == other.hash && inner == other.inner
+    init {
+        require(data.isNullOr { it.count > 0 })
+    }
 
-    operator fun plus(other: Mapping): Mapping = Mapping(inner = this.inner + other.inner)
+    fun keys() = object: Iterable<String> {
+        override fun iterator(): Iterator<String> = object: Iterator<String> {
 
-    override fun toString() = bindings.toString()
+            private var i = 0
 
-    fun retain(names: Set<String>): Mapping = Mapping(HashMap(inner).apply { keys.retainAll(names) })
+            override fun hasNext(): Boolean {
+                val data = this@Mapping.data
+                return data != null && i < data.count
+            }
+
+            override fun next(): String {
+                return BINDING_RLUT[this@Mapping.data!!.key(i++)]!!
+            }
+        }
+    }
+
+    fun asIterable() = object: Iterable<Pair<String, Quad.Term>> {
+
+        override fun iterator() = object: Iterator<Pair<String, Quad.Term>> {
+
+            private var i = 0
+
+            override fun hasNext(): Boolean {
+                val data = this@Mapping.data
+                return data != null && i < data.count
+            }
+
+            override fun next(): Pair<String, Quad.Term> {
+                data as IntIntPair
+                return (BINDING_RLUT[this@Mapping.data.key(i)]!! to TERM_RLUT[this@Mapping.data.value(i)]!!).also { ++i }
+            }
+        }
+
+    }
+
+    fun join(other: Mapping): Mapping? {
+        return when (val count = count(data, other.data)) {
+            -1 -> null
+            0 -> Mapping(null)
+            else -> {
+                Mapping(combine(data, other.data, count))
+            }
+        }
+    }
+
+    operator fun plus(other: Mapping): Mapping = join(other)!!
+
+    fun compatibleWith(other: Mapping): Boolean {
+        return count(this.data, other.data) != -1
+    }
+
+    fun retain(names: Set<String>): Mapping {
+        if (data == null) {
+            return this
+        }
+        val resolved = names
+            .mapNotNullTo(mutableSetOf()) { binding -> resolveBinding(binding).takeIf { data.search(it) != -1 } }
+            .ifEmpty { return EmptyMapping }
+        val result = IntArray(resolved.size * 2)
+        var i = 0
+        resolved.sorted().forEach { id ->
+            result[i] = id
+            result[i + 1] = this[id]!!
+            i += 2
+        }
+        return Mapping(data = result.into())
+    }
+
+    fun toMap(): Map<String, Quad.Term> {
+        return if (data == null) emptyMap() else buildMap(data.count) {
+            repeat(data.count) {
+                put(BINDING_RLUT[data.key(it)]!!, TERM_RLUT[data.value(it)]!!)
+            }
+        }
+    }
+
+    fun isEmpty() = data == null /* zero-sized data is not allowed! */
+
+    operator fun get(binding: String): Quad.Term? {
+        return TERM_RLUT[get(resolveBinding(binding))]
+    }
+
+    private operator fun get(id: Int): Int? = when {
+        data == null -> null
+        else -> data.search(id).takeIf { it != -1 }?.let { data.value(it) }
+    }
+
+    companion object {
+
+        // FIXME this one can be "fixed" based on the query
+        private val BINDING_LUT = mutableMapOf<String, Int>()
+        // FIXME this one can be an array
+        private val BINDING_RLUT = mutableMapOf<Int, String>()
+        private val TERM_LUT = mutableMapOf<Quad.Term, Int>()
+        private val TERM_RLUT = mutableMapOf<Int, Quad.Term>()
+
+        private fun convert(input: Map<String, Quad.Term>): IntIntPair? {
+            return if (input.isEmpty()) null else input.map { resolveBinding(it.key) to resolveTerm(it.value) }.sortedBy { it.first }.flatten().into()
+        }
+
+        private fun convert(input: Iterable<Pair<String, Quad.Term>>): IntIntPair? {
+            return if (!input.iterator().hasNext()) null else input.map { resolveBinding(it.first) to resolveTerm(it.second) }.sortedBy { it.first }.flatten().into()
+        }
+
+        private fun resolveBinding(name: String): Int {
+            return BINDING_LUT.getOrPut(name) { BINDING_RLUT[BINDING_LUT.size] = name; BINDING_LUT.size }
+        }
+
+        private fun resolveTerm(term: Quad.Term): Int {
+            return TERM_LUT.getOrPut(term) { TERM_RLUT[TERM_RLUT.size] = term; TERM_LUT.size }
+        }
+
+        private fun List<Pair<Int, Int>>.flatten(): IntArray {
+            val result = IntArray(size * 2)
+            forEachIndexed { i, (a, b) ->
+                result[2 * i] = a
+                result[2 * i + 1] = b
+            }
+            return result
+        }
+
+        /**
+         * Counts the total number of bindings that would be part of this mapping, or -1 if incompatible
+         */
+        private fun count(left: IntIntPair?, right: IntIntPair?): Int {
+            when {
+                left == null && right == null -> {
+                    return 0
+                }
+                left == null && right != null -> {
+                    return right.count
+                }
+                right == null && left != null -> {
+                    return left.count
+                }
+                else -> {
+                    left!!
+                    right!!
+                    var pos1 = 0
+                    var pos2 = 0
+                    var count = 0
+                    while (true) {
+                        when {
+                            left.key(pos1) < right.key(pos2) -> {
+                                count += 1
+                                ++pos1
+                                if (pos1 == left.count) {
+                                    return count + right.count - pos2
+                                }
+                            }
+                            left.key(pos1) > right.key(pos2) -> {
+                                count += 1
+                                ++pos2
+                                if (pos2 == right.count) {
+                                    return count + left.count - pos1
+                                }
+                            }
+                            else /* == */ -> {
+                                if (left.value(pos1) != right.value(pos2)) {
+                                    return -1
+                                }
+                                count += 1
+                                ++pos1
+                                ++pos2
+                                if (pos1 == left.count) {
+                                    return count + right.count - pos2
+                                }
+                                if (pos2 == right.count) {
+                                    return count + left.count - pos1
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun combine(left: IntIntPair?, right: IntIntPair?, size: Int): IntIntPair {
+            require(left != null || right != null)
+            if (left == null) {
+                return right!!
+            }
+            if (right == null) {
+                return left
+            }
+            val result = IntArray(size * 2)
+            var pos1 = 0
+            var pos2 = 0
+            var i = 0
+            while (true) {
+                when {
+                    left.key(pos1) < right.key(pos2) -> {
+                        result[i] = left.key(pos1)
+                        result[i + 1] = left.value(pos1)
+                        ++pos1
+                        if (pos1 == left.count) {
+                            while (pos2 < right.count) {
+                                i += 2
+                                result[i] = right.key(pos2)
+                                result[i + 1] = right.value(pos2)
+                                ++pos2
+                            }
+                            return result.into()
+                        }
+                    }
+                    left.key(pos1) > right.key(pos2) -> {
+                        result[i] = right.key(pos2)
+                        result[i + 1] = right.value(pos2)
+                        ++pos2
+                        if (pos2 == right.count) {
+                            while (pos1 < left.count) {
+                                i += 2
+                                result[i] = left.key(pos1)
+                                result[i + 1] = left.value(pos1)
+                                ++pos1
+                            }
+                            return result.into()
+                        }
+                    }
+                    else /* == */ -> {
+                        result[i] = left.key(pos1)
+                        result[i + 1] = left.value(pos1)
+                        ++pos1
+                        ++pos2
+                        if (pos1 == left.count) {
+                            while (pos2 < right.count) {
+                                i += 2
+                                result[i] = right.key(pos2)
+                                result[i + 1] = right.value(pos2)
+                                ++pos2
+                            }
+                            return result.into()
+                        }
+                        if (pos2 == right.count) {
+                            while (pos1 < left.count) {
+                                i += 2
+                                result[i] = left.key(pos1)
+                                result[i + 1] = left.value(pos1)
+                                ++pos1
+                            }
+                            return result.into()
+                        }
+                    }
+                }
+                i += 2
+            }
+        }
+
+        private fun IntArray.into() = IntIntPair(value = this)
+
+    }
+
+    private class IntIntPair(private val value: IntArray) {
+
+        val count = value.size / 2
+        private val hashCode = value.contentHashCode()
+
+        fun key(index: Int): Int {
+            return value[2 * index]
+        }
+
+        fun value(index: Int): Int {
+            return value[2 * index + 1]
+        }
+
+        override fun toString() = (0..<count).joinToString { "${key(it)}: ${value(it)}" }
+
+        override fun equals(other: Any?): Boolean {
+            if (other !is IntIntPair) {
+                return false
+            }
+            return value.contentEquals(other.value)
+        }
+
+        override fun hashCode(): Int {
+            return hashCode
+        }
+
+        /**
+         * Returns the index associated with [keyValue], or -1 if not found.
+         * The following holds true:
+         * ```kt
+         * val result = data.search(2)
+         * (result == -1 || data.key(result) == 2) == true
+         * ```
+         * This makes it possible to retrieve the value associated with that key
+         * ```kt
+         * data.value(result) // value associated with `id=2`
+         * ```
+         */
+        fun search(keyValue: Int): Int {
+            var min = 0
+            var max = count - 1
+            while (min <= max) {
+                val mid = min + (max - min) / 2
+                val ele = key(mid)
+                when {
+                    keyValue == ele -> return mid
+                    keyValue < ele -> max = mid - 1
+                    ele < keyValue -> min = mid + 1
+                }
+            }
+            return -1
+        }
+
+    }
 
 }
 
-val EmptyMapping = Mapping(emptyMap())
+val EmptyMapping = Mapping(emptyList())
 
 fun mappingOf(vararg pairs: Pair<String, Quad.Term>): Mapping =
-    Mapping(inner = HashMap<String, Quad.Term>(pairs.size).also { it.putAll(pairs) })
+    Mapping(pairs.asIterable())
 
 @JvmName("mappingOfNullable")
-fun mappingOf(vararg pairs: Pair<String?, Quad.Term>): Mapping = HashMap<String, Quad.Term>(pairs.size)
-    .also { map ->
-        pairs.forEach { (first, second) ->
-            if (first != null) {
-                map[first] = second
-            }
-        }
-    }.toMapping()
-
-fun Bindings.toMapping() = Mapping(inner = this)
+fun mappingOf(vararg pairs: Pair<String?, Quad.Term>): Mapping =
+    @Suppress("UNCHECKED_CAST")
+    Mapping(pairs.filter { it.first != null } as List<Pair<String, Quad.Term>>)
 
 fun emptyMapping(): Mapping = EmptyMapping

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Mapping.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Mapping.kt
@@ -67,16 +67,17 @@ value class Mapping private constructor(private val data: IntIntPair?) {
         return count(this.data, other.data) != -1
     }
 
-    fun retain(context: QueryContext, names: Set<String>): Mapping {
+    fun retain(bindings: BindingIdentifierSet): Mapping {
         if (data == null) {
             return this
         }
-        val resolved = names
-            .mapNotNullTo(mutableSetOf()) { binding -> context.resolveBinding(binding).takeIf { data.search(it) != -1 } }
+        val present = bindings
+            // TODO(perf) the fact that these bindings are sorted, this filter can abuse this fact
+            .filter { id -> data.search(id) != -1 }
             .ifEmpty { return EmptyMapping }
-        val result = IntArray(resolved.size * 2)
+        val result = IntArray(present.size * 2)
         var i = 0
-        resolved.sorted().forEach { id ->
+        present.forEach { id ->
             result[i] = id
             result[i + 1] = this[id]!!
             i += 2

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Mapping.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Mapping.kt
@@ -51,6 +51,25 @@ value class Mapping private constructor(private val data: IntIntPair?) {
 
     }
 
+    fun asIterable() = object: Iterable<Pair<BindingIdentifier, TermIdentifier>> {
+
+        override fun iterator() = object: Iterator<Pair<BindingIdentifier, TermIdentifier>> {
+
+            private var i = 0
+
+            override fun hasNext(): Boolean {
+                val data = this@Mapping.data
+                return data != null && i < data.count
+            }
+
+            override fun next(): Pair<BindingIdentifier, TermIdentifier> {
+                data as IntIntPair
+                return (BindingIdentifier(this@Mapping.data.key(i)) to TermIdentifier(this@Mapping.data.value(i))).also { ++i }
+            }
+        }
+
+    }
+
     fun join(other: Mapping): Mapping? {
         return when (val count = count(data, other.data)) {
             -1 -> null
@@ -72,6 +91,7 @@ value class Mapping private constructor(private val data: IntIntPair?) {
             return this
         }
         val present = bindings
+            .asIntIterable()
             // TODO(perf) the fact that these bindings are sorted, this filter can abuse this fact
             .filter { id -> data.search(id) != -1 }
             .ifEmpty { return EmptyMapping }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/QueryContext.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/QueryContext.kt
@@ -1,0 +1,15 @@
+package dev.tesserakt.sparql.runtime.evaluation
+
+import dev.tesserakt.rdf.types.Quad
+
+interface QueryContext {
+
+    fun resolveBinding(value: String): Int
+
+    fun resolveTerm(value: Quad.Term): Int
+
+    fun resolveBinding(id: Int): String
+
+    fun resolveTerm(id: Int): Quad.Term
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/QueryContextImpl.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/QueryContextImpl.kt
@@ -1,0 +1,41 @@
+package dev.tesserakt.sparql.runtime.evaluation
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.types.QueryStructure
+import dev.tesserakt.sparql.types.extractAllBindings
+
+class QueryContextImpl(ast: QueryStructure): QueryContext {
+
+    // note: this cannot be a read only list, as some add bindings during initialisation, such as repeating paths
+    private val bindings = ast.body.extractAllBindings().mapTo(mutableListOf()) { it.name }
+    private val bindingsLut = bindings.withIndex().associateTo(mutableMapOf()) { (i, value) -> value to i }
+
+    private val terms = mutableMapOf<Quad.Term, Int>()
+    private val termsLut = mutableMapOf<Int, Quad.Term>()
+
+    override fun resolveBinding(value: String): Int {
+        return bindingsLut.getOrPut(value) {
+            val i = bindings.size
+            require(bindingsLut.size == i)
+            bindings.add(value)
+            i
+        }
+    }
+
+    override fun resolveTerm(value: Quad.Term): Int {
+        return terms.getOrPut(value) {
+            val i = terms.size
+            termsLut[i] = value
+            i
+        }
+    }
+
+    override fun resolveBinding(id: Int): String {
+        return bindings[id]
+    }
+
+    override fun resolveTerm(id: Int): Quad.Term {
+        return termsLut[id]!!
+    }
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/QueryContextImpl.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/QueryContextImpl.kt
@@ -11,7 +11,9 @@ class QueryContextImpl(ast: QueryStructure): QueryContext {
     private val bindingsLut = bindings.withIndex().associateTo(mutableMapOf()) { (i, value) -> value to i }
 
     private val terms = mutableMapOf<Quad.Term, Int>()
-    private val termsLut = mutableMapOf<Int, Quad.Term>()
+    // as terms are never removed from an active context, we can keep it as a regular list without risking IDs
+    // shifting over
+    private val termsLut = mutableListOf<Quad.Term>()
 
     override fun resolveBinding(value: String): Int {
         return bindingsLut.getOrPut(value) {
@@ -25,7 +27,7 @@ class QueryContextImpl(ast: QueryStructure): QueryContext {
     override fun resolveTerm(value: Quad.Term): Int {
         return terms.getOrPut(value) {
             val i = terms.size
-            termsLut[i] = value
+            termsLut.add(value)
             i
         }
     }
@@ -35,7 +37,7 @@ class QueryContextImpl(ast: QueryStructure): QueryContext {
     }
 
     override fun resolveTerm(id: Int): Quad.Term {
-        return termsLut[id]!!
+        return termsLut[id]
     }
 
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/TermIdentifier.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/TermIdentifier.kt
@@ -1,0 +1,13 @@
+package dev.tesserakt.sparql.runtime.evaluation
+
+import dev.tesserakt.rdf.types.Quad
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class TermIdentifier(val id: Int) {
+
+    companion object {
+        fun QueryContext.get(term: TermIdentifier): Quad.Term = resolveTerm(id = term.id)
+    }
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Util.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Util.kt
@@ -2,26 +2,21 @@ package dev.tesserakt.sparql.runtime.evaluation
 
 import dev.tesserakt.sparql.runtime.stream.Stream
 import dev.tesserakt.sparql.runtime.stream.mapped
-import dev.tesserakt.util.compatibleWith
 
 
 operator fun MappingDelta.plus(other: MappingDelta): MappingDelta? {
     return when {
         this is MappingAddition &&
-        other is MappingAddition &&
-        value.compatibleWith(other.value) ->
-            MappingAddition(
-                value = value + other.value,
-                origin = origin
-            )
+        other is MappingAddition -> value.join(other.value)?.let { MappingAddition(it, origin) }
 
         this is MappingDeletion &&
-        other is MappingDeletion &&
-        value.compatibleWith(other.value) ->
-            MappingDeletion(
-                value = value + other.value,
-                origin = origin
-            )
+        other is MappingDeletion ->
+            value.join(other.value)?.let {
+                MappingDeletion(
+                    value = it,
+                    origin = origin
+                )
+            }
 
         else -> null
     }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/BasicGraphPatternState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/BasicGraphPatternState.kt
@@ -2,17 +2,18 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.DataDelta
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
+import dev.tesserakt.sparql.runtime.evaluation.QueryContext
 import dev.tesserakt.sparql.runtime.stream.Stream
 import dev.tesserakt.sparql.runtime.stream.collect
 import dev.tesserakt.sparql.types.GraphPattern
 import dev.tesserakt.sparql.util.Cardinality
 import dev.tesserakt.sparql.util.getAllNamedBindings
 
-class BasicGraphPatternState(ast: GraphPattern) {
+class BasicGraphPatternState(val context: QueryContext, ast: GraphPattern) {
 
-    private val group = GroupPatternState(ast.patterns, ast.unions)
+    private val group = GroupPatternState(context, ast.patterns, ast.unions)
 
-    private val filters = GraphPatternFilterState(parent = group, filters = ast.filters)
+    private val filters = GraphPatternFilterState(context, parent = group, filters = ast.filters)
 
     /**
      * A collection of all bindings found inside this query body; it is not guaranteed that all solutions generated

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExclusionFilterState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExclusionFilterState.kt
@@ -33,8 +33,8 @@ sealed interface ExclusionFilterState: MutableFilterState {
      *  collection (which may not be empty!)
      */
     class Narrow(
-        private val context: QueryContext,
-        private val commonBindingNames: Set<String>,
+        context: QueryContext,
+        commonBindingNames: Set<String>,
         private val state: BasicGraphPatternState,
     ) : ExclusionFilterState {
 
@@ -42,11 +42,12 @@ sealed interface ExclusionFilterState: MutableFilterState {
             require(commonBindingNames.isNotEmpty()) { "Invalid filter use detected!" }
         }
 
+        private val commonBindingNames = BindingIdentifierSet(context, commonBindingNames)
         // tracking what binding groups are "invalid" (= should be filtered out)
         private val filtered = Counter<Mapping>()
 
         override fun peek(delta: DataDelta): OptimisedStream<MappingDelta> {
-            val changes = state.peek(delta).mapped { it.map { it.retain(context, commonBindingNames) } }
+            val changes = state.peek(delta).mapped { it.map { it.retain(commonBindingNames) } }
             // these changes, combined with the `filtered` state, will result in a set of bindings that can now be joined
             //  with to find all resulting changes:
             // * change additions (not in filtered now, but in `changes`) => these have to be removed outwards
@@ -85,7 +86,7 @@ sealed interface ExclusionFilterState: MutableFilterState {
             // applying the impact of the new delta to it
             state
                 .peek(delta)
-                .mapped { it.map { it.retain(context, commonBindingNames) } }
+                .mapped { it.map { it.retain(commonBindingNames) } }
                 .forEach { mappingDelta ->
                     when (mappingDelta) {
                         is MappingAddition -> total.increment(mappingDelta.value)
@@ -106,7 +107,7 @@ sealed interface ExclusionFilterState: MutableFilterState {
         override fun process(delta: DataDelta) {
             state
                 .peek(delta)
-                .mapped { it.map { it.retain(context, commonBindingNames) } }
+                .mapped { it.map { it.retain(commonBindingNames) } }
                 .forEach { mappingDelta ->
                     when (mappingDelta) {
                         is MappingAddition -> filtered.increment(mappingDelta.value)

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExclusionFilterState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExclusionFilterState.kt
@@ -4,7 +4,6 @@ import dev.tesserakt.sparql.runtime.evaluation.*
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.Filter
 import dev.tesserakt.sparql.util.Counter
-import dev.tesserakt.util.compatibleWith
 import dev.tesserakt.util.replace
 
 sealed interface ExclusionFilterState: MutableFilterState {
@@ -34,6 +33,7 @@ sealed interface ExclusionFilterState: MutableFilterState {
      *  collection (which may not be empty!)
      */
     class Narrow(
+        private val context: QueryContext,
         private val commonBindingNames: Set<String>,
         private val state: BasicGraphPatternState,
     ) : ExclusionFilterState {
@@ -46,7 +46,7 @@ sealed interface ExclusionFilterState: MutableFilterState {
         private val filtered = Counter<Mapping>()
 
         override fun peek(delta: DataDelta): OptimisedStream<MappingDelta> {
-            val changes = state.peek(delta).mapped { it.map { it.retain(commonBindingNames) } }
+            val changes = state.peek(delta).mapped { it.map { it.retain(context, commonBindingNames) } }
             // these changes, combined with the `filtered` state, will result in a set of bindings that can now be joined
             //  with to find all resulting changes:
             // * change additions (not in filtered now, but in `changes`) => these have to be removed outwards
@@ -85,7 +85,7 @@ sealed interface ExclusionFilterState: MutableFilterState {
             // applying the impact of the new delta to it
             state
                 .peek(delta)
-                .mapped { it.map { it.retain(commonBindingNames) } }
+                .mapped { it.map { it.retain(context, commonBindingNames) } }
                 .forEach { mappingDelta ->
                     when (mappingDelta) {
                         is MappingAddition -> total.increment(mappingDelta.value)
@@ -106,7 +106,7 @@ sealed interface ExclusionFilterState: MutableFilterState {
         override fun process(delta: DataDelta) {
             state
                 .peek(delta)
-                .mapped { it.map { it.retain(commonBindingNames) } }
+                .mapped { it.map { it.retain(context, commonBindingNames) } }
                 .forEach { mappingDelta ->
                     when (mappingDelta) {
                         is MappingAddition -> filtered.increment(mappingDelta.value)
@@ -198,13 +198,14 @@ sealed interface ExclusionFilterState: MutableFilterState {
 
     companion object {
 
-        operator fun invoke(parent: GroupPatternState, filter: Filter.NotExists): ExclusionFilterState {
-            val state = BasicGraphPatternState(filter.pattern)
+        operator fun invoke(context: QueryContext, parent: GroupPatternState, filter: Filter.NotExists): ExclusionFilterState {
+            val state = BasicGraphPatternState(context, filter.pattern)
             val externalBindings = parent.bindings.intersect(state.bindings)
             return if (externalBindings.isEmpty()) {
                 Broad(state = state)
             } else {
                 Narrow(
+                    context = context,
                     commonBindingNames = externalBindings,
                     state = state
                 )

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExpressionFilter.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExpressionFilter.kt
@@ -1,6 +1,7 @@
 package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
+import dev.tesserakt.sparql.runtime.evaluation.QueryContext
 import dev.tesserakt.sparql.runtime.stream.Stream
 import dev.tesserakt.sparql.runtime.stream.filtered
 import dev.tesserakt.sparql.types.Expression
@@ -9,7 +10,7 @@ import kotlin.jvm.JvmInline
 @JvmInline
 value class ExpressionFilter private constructor(private val compiled: FilterExpression): StatelessFilter {
 
-    constructor(expression: Expression) : this(compiled = FilterExpression(expression))
+    constructor(context: QueryContext, expression: Expression) : this(compiled = FilterExpression(context, expression))
 
     override fun filter(input: Stream<MappingDelta>): Stream<MappingDelta> {
         return input.filtered { compiled.test(it.value) }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GraphPatternFilterState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GraphPatternFilterState.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.DataDelta
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
+import dev.tesserakt.sparql.runtime.evaluation.QueryContext
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.Filter
 import dev.tesserakt.sparql.util.Bitmask
@@ -207,14 +208,14 @@ data class GraphPatternFilterState(
 
     companion object {
 
-        operator fun invoke(parent: GroupPatternState, filters: List<Filter>): GraphPatternFilterState {
+        operator fun invoke(context: QueryContext, parent: GroupPatternState, filters: List<Filter>): GraphPatternFilterState {
             val stateful = mutableListOf<MutableFilterState>()
             val stateless = mutableListOf<StatelessFilter>()
             filters.forEach { filter ->
                 when (filter) {
-                    is Filter.Exists -> stateful.add(InclusionFilterState(parent, filter))
-                    is Filter.NotExists -> stateful.add(ExclusionFilterState(parent, filter))
-                    is Filter.Predicate -> stateless.add(ExpressionFilter(filter.expression))
+                    is Filter.Exists -> stateful.add(InclusionFilterState(context, parent, filter))
+                    is Filter.NotExists -> stateful.add(ExclusionFilterState(context, parent, filter))
+                    is Filter.Predicate -> stateless.add(ExpressionFilter(context, filter.expression))
                     is Filter.Regex -> TODO()
                 }
             }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GroupPatternState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GroupPatternState.kt
@@ -1,18 +1,15 @@
 package dev.tesserakt.sparql.runtime.query
 
-import dev.tesserakt.sparql.runtime.evaluation.DataDelta
-import dev.tesserakt.sparql.runtime.evaluation.MappingAddition
-import dev.tesserakt.sparql.runtime.evaluation.MappingDeletion
-import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
+import dev.tesserakt.sparql.runtime.evaluation.*
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.TriplePatternSet
 import dev.tesserakt.sparql.types.Union
 import dev.tesserakt.sparql.util.Cardinality
 
-class GroupPatternState(pattern: TriplePatternSet, unions: List<Union>): MutableJoinState {
+class GroupPatternState(context: QueryContext, pattern: TriplePatternSet, unions: List<Union>): MutableJoinState {
 
-    private val patterns = JoinTree(pattern)
-    private val unions = JoinTree(unions)
+    private val patterns = JoinTree(context, pattern)
+    private val unions = JoinTree(context, unions)
 
     override val cardinality: Cardinality
         get() = patterns.cardinality * unions.cardinality

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
@@ -295,8 +295,8 @@ sealed interface JoinTree: MutableJoinState {
                 }
 
                 override fun join(delta: MappingDelta): Stream<MappingDelta> {
-                    val leftOverlap = delta.value.bindings.keys.count { it in left.bindings }
-                    val rightOverlap = delta.value.bindings.keys.count { it in right.bindings }
+                    val leftOverlap = delta.value.keys().count { it in left.bindings }
+                    val rightOverlap = delta.value.keys().count { it in right.bindings }
                     return if (leftOverlap > rightOverlap) {
                         right.join(left.join(delta).optimisedForSingleUse(left.cardinality))
                     } else {

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
@@ -110,13 +110,13 @@ sealed interface JoinTree: MutableJoinState {
         companion object {
 
             @JvmName("forPatterns")
-            operator fun invoke(patterns: List<TriplePattern>) = None(
-                states = patterns.map { TriplePatternState.from(it) }
+            operator fun invoke(context: QueryContext, patterns: List<TriplePattern>) = None(
+                states = patterns.map { TriplePatternState.from(context, it) }
             )
 
             @JvmName("forUnions")
-            operator fun invoke(unions: List<Union>) = None(
-                states = unions.map { UnionState(it) }
+            operator fun invoke(context: QueryContext, unions: List<Union>) = None(
+                states = unions.map { UnionState(context, it) }
             )
 
         }
@@ -183,6 +183,7 @@ sealed interface JoinTree: MutableJoinState {
             }
 
             class Connected<J: MutableJoinState, L: Node<J>, R: Node<J>>(
+                context: QueryContext,
                 private val left: L,
                 private val right: R,
                 indexes: List<String>
@@ -191,6 +192,7 @@ sealed interface JoinTree: MutableJoinState {
                 override val bindings = left.bindings + right.bindings
 
                 private val buf = MappingArray(
+                    context = context,
                     bindings = indexes.intersect(bindings)
                         .also { check(it.isNotEmpty()) { "Connected node used with no valid indices! This is not allowed!" } }
                 )
@@ -272,6 +274,7 @@ sealed interface JoinTree: MutableJoinState {
             }
 
             class Disconnected<J: MutableJoinState, L: Node<J>, R: Node<J>>(
+                val context: QueryContext,
                 val left: L,
                 val right: R
             ): Node<J> {
@@ -295,8 +298,8 @@ sealed interface JoinTree: MutableJoinState {
                 }
 
                 override fun join(delta: MappingDelta): Stream<MappingDelta> {
-                    val leftOverlap = delta.value.keys().count { it in left.bindings }
-                    val rightOverlap = delta.value.keys().count { it in right.bindings }
+                    val leftOverlap = delta.value.keys(context).count { it in left.bindings }
+                    val rightOverlap = delta.value.keys(context).count { it in right.bindings }
                     return if (leftOverlap > rightOverlap) {
                         right.join(left.join(delta).optimisedForSingleUse(left.cardinality))
                     } else {
@@ -384,23 +387,23 @@ sealed interface JoinTree: MutableJoinState {
         companion object {
 
             @JvmName("forPatterns")
-            operator fun invoke(patterns: List<TriplePattern>): Dynamic<TriplePatternState<*>> {
-                val states = patterns.map { TriplePatternState.from(it) }
-                val root = build(states)
+            operator fun invoke(context: QueryContext, patterns: List<TriplePattern>): Dynamic<TriplePatternState<*>> {
+                val states = patterns.map { TriplePatternState.from(context, it) }
+                val root = build(context, states)
                 return Dynamic(root)
             }
 
             @JvmName("forUnions")
-            operator fun invoke(unions: List<Union>): Dynamic<UnionState> {
-                val states = unions.map { UnionState(it) }
-                val root = build(states)
+            operator fun invoke(context: QueryContext, unions: List<Union>): Dynamic<UnionState> {
+                val states = unions.map { UnionState(context, it) }
+                val root = build(context, states)
                 return Dynamic(root)
             }
 
             /**
              * Builds a tree, returning the tree's root, using the provided [states]
              */
-            private fun <J: MutableJoinState> build(states: List<J>): Node<J> {
+            private fun <J: MutableJoinState> build(context: QueryContext, states: List<J>): Node<J> {
                 check(states.isNotEmpty())
                 if (states.size == 1) {
                     // hardly a tree, but what can we do
@@ -409,9 +412,9 @@ sealed interface JoinTree: MutableJoinState {
                 // TODO(perf): actually check individual states on overlapping bindings, have them be connected nodes,
                 //  with the total index list depending on the not-yet-inserted patterns
                 val remaining = states.mapTo(ArrayList(states.size)) { Node.Leaf(it) }
-                var result: Node<J> = Node.Disconnected(left = remaining.removeFirst(), right = remaining.removeFirst())
+                var result: Node<J> = Node.Disconnected(context = context, left = remaining.removeFirst(), right = remaining.removeFirst())
                 while (remaining.isNotEmpty()) {
-                    result = Node.Disconnected(left = result, right = remaining.removeFirst())
+                    result = Node.Disconnected(context = context, left = result, right = remaining.removeFirst())
                 }
                 return result
             }
@@ -445,21 +448,21 @@ sealed interface JoinTree: MutableJoinState {
     companion object {
 
         @JvmName("forPatterns")
-        operator fun invoke(patterns: List<TriplePattern>) = when {
+        operator fun invoke(context: QueryContext, patterns: List<TriplePattern>) = when {
             // TODO(perf) specialised empty case
             // TODO(perf) also based on binding overlap
-            patterns.size >= 2 -> Dynamic(patterns)
+            patterns.size >= 2 -> Dynamic(context, patterns)
             patterns.isEmpty() -> Empty
-            else -> None(patterns)
+            else -> None(context, patterns)
         }
 
         @JvmName("forUnions")
-        operator fun invoke(unions: List<Union>) = when {
+        operator fun invoke(context: QueryContext, unions: List<Union>) = when {
             // TODO(perf) specialised empty case
             // TODO(perf) also based on binding overlap
-            unions.size >= 2 -> Dynamic(unions)
+            unions.size >= 2 -> Dynamic(context, unions)
             unions.isEmpty() -> Empty
-            else -> None(unions)
+            else -> None(context, unions)
         }
 
     }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
@@ -12,7 +12,8 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
 
     inner class Processor {
 
-        private val state = BasicGraphPatternState(ast = Compat.apply(ast.body))
+        val context = QueryContextImpl(ast)
+        private val state = BasicGraphPatternState(context, ast = Compat.apply(ast.body))
 
         /**
          * Required when setting up the initial state: sets up initial state
@@ -28,11 +29,11 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
                     )
                 )
                 // mapping them to insertion changes, combining them into the expected return type
-                .map { bindings -> this@QueryState.process(ResultChange.New(BindingsImpl(bindings.value))).value }
+                .map { bindings -> this@QueryState.process(ResultChange.New(BindingsImpl(context, bindings.value))).value }
         }
 
         fun process(data: DataDelta): List<ResultChange<BindingsImpl>> {
-            return state.insert(data).map { it.into() }
+            return state.insert(data).map { it.into(context) }
         }
 
         fun debugInformation() = state.debugInformation()
@@ -49,9 +50,9 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
         value class Removed<T>(override val value: T): ResultChange<T>
 
         companion object {
-            fun MappingDelta.into() = when (this) {
-                is MappingAddition -> New(BindingsImpl(value))
-                is MappingDeletion -> Removed(BindingsImpl(value))
+            fun MappingDelta.into(context: QueryContext) = when (this) {
+                is MappingAddition -> New(BindingsImpl(context, value))
+                is MappingDeletion -> Removed(BindingsImpl(context, value))
             }
         }
 

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
@@ -1,6 +1,5 @@
 package dev.tesserakt.sparql.runtime.query
 
-import dev.tesserakt.sparql.Bindings
 import dev.tesserakt.sparql.runtime.compat.Compat
 import dev.tesserakt.sparql.runtime.evaluation.*
 import dev.tesserakt.sparql.runtime.query.QueryState.ResultChange.Companion.into
@@ -29,10 +28,10 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
                     )
                 )
                 // mapping them to insertion changes, combining them into the expected return type
-                .map { bindings -> this@QueryState.process(ResultChange.New(bindings.value)).value }
+                .map { bindings -> this@QueryState.process(ResultChange.New(BindingsImpl(bindings.value))).value }
         }
 
-        fun process(data: DataDelta): List<ResultChange<Bindings>> {
+        fun process(data: DataDelta): List<ResultChange<BindingsImpl>> {
             return state.insert(data).map { it.into() }
         }
 
@@ -51,13 +50,13 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
 
         companion object {
             fun MappingDelta.into() = when (this) {
-                is MappingAddition -> New(value.bindings)
-                is MappingDeletion -> Removed(value.bindings)
+                is MappingAddition -> New(BindingsImpl(value))
+                is MappingDeletion -> Removed(BindingsImpl(value))
             }
         }
 
     }
 
-    abstract fun process(change: ResultChange<Bindings>): ResultChange<ResultType>
+    abstract fun process(change: ResultChange<BindingsImpl>): ResultChange<ResultType>
 
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/SelectQueryState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/SelectQueryState.kt
@@ -1,17 +1,16 @@
 package dev.tesserakt.sparql.runtime.query
 
-import dev.tesserakt.sparql.Bindings
+import dev.tesserakt.sparql.runtime.evaluation.BindingsImpl
 import dev.tesserakt.sparql.types.SelectQueryStructure
-import dev.tesserakt.util.associateWithNotNull
 
-class SelectQueryState(ast: SelectQueryStructure): QueryState<Bindings, SelectQueryStructure>(ast) {
+class SelectQueryState(ast: SelectQueryStructure): QueryState<BindingsImpl, SelectQueryStructure>(ast) {
 
     val variables = ast.bindings
 
-    override fun process(change: ResultChange<Bindings>): ResultChange<Bindings> {
+    override fun process(change: ResultChange<BindingsImpl>): ResultChange<BindingsImpl> {
         return when (change) {
-            is ResultChange.New -> ResultChange.New(variables.associateWithNotNull { change.value[it] })
-            is ResultChange.Removed -> ResultChange.Removed(variables.associateWithNotNull { change.value[it] })
+            is ResultChange.New -> ResultChange.New(change.value.retain(variables))
+            is ResultChange.Removed -> ResultChange.Removed(change.value.retain(variables))
         }
     }
 

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMultiJoin.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMultiJoin.kt
@@ -1,8 +1,8 @@
 package dev.tesserakt.sparql.runtime.stream
 
 import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.emptyMapping
 import dev.tesserakt.sparql.util.Cardinality
-import dev.tesserakt.util.compatibleWith
 
 class StreamMultiJoin(
     private val left: Stream<Mapping>,
@@ -19,7 +19,8 @@ class StreamMultiJoin(
         private var source2 = b.iterator()
 
         private var left = source1.next()
-        private lateinit var right: Mapping
+        // the empty mapping is never read from, so this is not an error (instant `increment()` call)
+        private var right: Mapping = emptyMapping()
 
         private var next: Mapping? = null
 
@@ -39,8 +40,9 @@ class StreamMultiJoin(
 
         private fun getNext(): Mapping? {
             while (increment()) {
-                if (left.compatibleWith(right)) {
-                    return left + right
+                val joined = left.join(right)
+                if (joined != null) {
+                    return joined
                 }
             }
             return null

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamSingleJoin.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamSingleJoin.kt
@@ -1,8 +1,8 @@
 package dev.tesserakt.sparql.runtime.stream
 
 import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.emptyMapping
 import dev.tesserakt.sparql.util.Cardinality
-import dev.tesserakt.util.compatibleWith
 
 class StreamSingleJoin(
     private val left: Mapping,
@@ -15,7 +15,8 @@ class StreamSingleJoin(
         private val source: Iterator<Mapping>,
     ): Iterator<Mapping> {
 
-        private lateinit var right: Mapping
+        // the empty mapping is never read from, so this is not an error (instant `increment()` call)
+        private var right: Mapping = emptyMapping()
 
         private var next: Mapping? = null
 
@@ -35,8 +36,9 @@ class StreamSingleJoin(
 
         private fun getNext(): Mapping? {
             while (increment()) {
-                if (left.compatibleWith(right)) {
-                    return left + right
+                val joined = left.join(right)
+                if (joined != null) {
+                    return joined
                 }
             }
             return null

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationDebug.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationDebug.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql
 
 import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.BindingsImpl
 import dev.tesserakt.sparql.runtime.evaluation.DataAddition
 import dev.tesserakt.sparql.runtime.evaluation.DataDeletion
 import dev.tesserakt.sparql.runtime.query.QueryState
@@ -57,7 +58,7 @@ class OngoingQueryEvaluationDebug<RT>(private val query: QueryState<RT, *>): Ong
         return processor.debugInformation()
     }
 
-    private fun process(change: QueryState.ResultChange<Bindings>) {
+    private fun process(change: QueryState.ResultChange<BindingsImpl>) {
         when (val mapped = query.process(change)) {
             is QueryState.ResultChange.New<*> -> {
                 _results.replace(mapped.value) { current -> (current ?: 0) + 1 }

--- a/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationRelease.kt
+++ b/sparql/src/commonMain/kotlin/dev/tesserakt/sparql/OngoingQueryEvaluationRelease.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql
 
 import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.BindingsImpl
 import dev.tesserakt.sparql.runtime.evaluation.DataAddition
 import dev.tesserakt.sparql.runtime.evaluation.DataDeletion
 import dev.tesserakt.sparql.runtime.query.QueryState
@@ -55,7 +56,7 @@ class OngoingQueryEvaluationRelease<RT>(private val query: QueryState<RT, *>): O
         return processor.debugInformation()
     }
 
-    private fun process(change: QueryState.ResultChange<Bindings>) {
+    private fun process(change: QueryState.ResultChange<BindingsImpl>) {
         when (val mapped = query.process(change)) {
             is QueryState.ResultChange.New<*> -> {
                 _results.replace(mapped.value) { current -> (current ?: 0) + 1 }

--- a/sparql/test/src/test/kotlin/CompilerTest.kt
+++ b/sparql/test/src/test/kotlin/CompilerTest.kt
@@ -126,20 +126,22 @@ class CompilerTest {
             require(this is SelectQueryStructure)
             val count = output!!.find { it.name == "count" }!!
             (count as SelectQueryStructure.ExpressionOutput).expression ==
-                    Expression.MathOp.Sum(
+                    Expression.MathOp(
                         lhs = Expression.BindingAggregate(
                             type = Expression.BindingAggregate.Type.AVG,
                             input = Expression.BindingValues("s"),
                             distinct = false
                         ),
-                        rhs = Expression.MathOp.Div(
+                        rhs = Expression.MathOp(
                             lhs = Expression.BindingAggregate(
                                 type = Expression.BindingAggregate.Type.MIN,
                                 input = Expression.BindingValues("s"),
                                 distinct = false
                             ),
-                            rhs = Expression.NumericLiteralValue(3L)
-                        )
+                            rhs = Expression.NumericLiteralValue(3L),
+                            operator = Expression.MathOp.Operator.DIV
+                        ),
+                        operator = Expression.MathOp.Operator.SUM
                     )
         }
         """
@@ -161,7 +163,7 @@ class CompilerTest {
             body.patterns.size == 1 &&
             body.patterns.first() == pattern &&
             ((avg as SelectQueryStructure.ExpressionOutput).expression as Expression.BindingAggregate).type == Expression.BindingAggregate.Type.AVG &&
-            (c as SelectQueryStructure.ExpressionOutput).expression is Expression.MathOp.Div
+            (c as SelectQueryStructure.ExpressionOutput).expression is Expression.MathOp
         }
         """
             SELECT * WHERE {

--- a/sparql/test/src/test/kotlin/MappingTest.kt
+++ b/sparql/test/src/test/kotlin/MappingTest.kt
@@ -1,0 +1,106 @@
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
+import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
+import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import org.junit.Test
+import kotlin.random.Random
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+private const val SIZE = 1000
+private const val VARIANCE = 50
+
+private typealias MapMapping = Map<String, Quad.Term>
+
+class MappingTest {
+
+    private val BINDINGS = listOf(
+        "person" to List(VARIANCE) { "http://example/person_${it}".asNamedTerm() },
+        "job" to List(VARIANCE) { "http://example/job_${it}".asNamedTerm() },
+        "name" to List(VARIANCE) { "http://example/name_${it}".asNamedTerm() },
+        "age" to List(VARIANCE) { it.asLiteralTerm() },
+    )
+
+    private fun createMapping(id: Int): MapMapping {
+        val rng = Random(id)
+        return BINDINGS.associate { it.first to it.second.random(rng) }.filter { rng.nextBoolean() }
+    }
+
+    private inline fun <K: Any, V: Any> Map<K, V>.compatibleWith(reference: Map<K, V>) =
+        reference.all { (refKey, refValue) -> val data = this[refKey]; data == null || data == refValue}
+
+
+    private fun join(a: MapMapping, b: MapMapping): MapMapping? {
+        return if (a.compatibleWith(b)) {
+            a + b
+        } else {
+            null
+        }
+    }
+
+    @Test
+    fun mappingConversion1() {
+        val data = List(100) { createMapping(it) }
+        val converted = data.map { Mapping(it) }
+        assertContentEquals(data, converted.map { it.toMap() })
+    }
+
+    @Test
+    fun mappingConversion2() {
+        val data = List(100) { createMapping(it) }
+        val converted = data.map { Mapping(it) }
+        repeat(data.size) { index ->
+            val map = data[index]
+            map.forEach { (key, value) ->
+                assertEquals(value, converted[index][key])
+            }
+        }
+    }
+
+    @Test
+    fun mappingConversion3() {
+        val data = List(100) { createMapping(it) }
+        val converted = data.map { Mapping(it) }
+        repeat(data.size) { index ->
+            assertContentEquals(
+                expected = data[index].map { it.toPair() }.sortedBy { it.first },
+                actual = converted[index].asIterable().sortedBy { it.first })
+        }
+    }
+
+    @Test
+    fun mappingConversion4() {
+        val data = List(100) { createMapping(it) }
+        val converted = data.map { Mapping(it) }
+        val rng = Random(1)
+        val subset = data.map { it.toMutableMap().apply { keys.retainAll { rng.nextBoolean() } } }
+        repeat(data.size) { index ->
+            assertContentEquals(
+                expected = subset[index].map { it.toPair() }.sortedBy { it.first },
+                actual = converted[index].retain(subset[index].keys).asIterable().sortedBy { it.first })
+        }
+    }
+
+    @Test
+    fun joinMappings() {
+        val random = Random(1)
+        val left = mutableListOf<MapMapping>()
+        val right = mutableListOf<MapMapping>()
+        repeat(SIZE) {
+            val new = createMapping(random.nextInt())
+            if (random.nextBoolean()) {
+                left.add(new)
+            } else {
+                right.add(new)
+            }
+        }
+        val l = left.map { Mapping(it) }
+        val r = right.map { Mapping(it) }
+        val original = left.flatMap { l -> right.mapNotNull { r -> join(l, r) } }
+        val new = l.flatMap { l -> r.mapNotNull { r -> l.join(r) } }
+            .map { it.toMap() }
+        assertContentEquals(original, new)
+    }
+
+}

--- a/sparql/test/src/test/kotlin/StreamTest.kt
+++ b/sparql/test/src/test/kotlin/StreamTest.kt
@@ -3,7 +3,6 @@ import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.sparql.runtime.evaluation.mappingOf
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.util.Counter
-import dev.tesserakt.util.compatibleWith
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -43,7 +42,7 @@ class StreamTest {
         val b = (7..10).map { mappingOf("value" to it.asLiteralTerm()) }
             .toStream()
         val joined1 = a.join(b)
-        val joined2 = a.product(b).mappedNonNull { (a, b) -> if (a.compatibleWith(b)) a + b else null }
+        val joined2 = a.product(b).mappedNonNull { (a, b) -> a.join(b) }
         val check = Counter(joined1)
         assertEquals(joined1.cardinality, joined2.cardinality)
         assertTrue { check.current.size == 4 }


### PR DESCRIPTION
Reworked the mapping structure, now internally using an `IntArray` to represent binding name and value pairs, making compatibility checks, join logic and mapping creation cheaper. The index values for these binding name and values are stored inside a query context object, that are closely associated to the active query state.

The benchmark runner implementation has been adjusted to calculate a checksum, ensuring all values of a solution are iterated over, adjusting the measured benchmarking time 