### PR TITLE
Fixed Gradle script errors on missing local properties file

### DIFF
--- a/testing/bench/sparql/build.gradle.kts
+++ b/testing/bench/sparql/build.gradle.kts
@@ -50,11 +50,11 @@ kotlin {
     }
 }
 
-fun local(name: String): String? {
+fun local(name: String): String? = runCatching {
     val properties = Properties()
     properties.load(File(rootDir.absolutePath + "/local.properties").inputStream())
     return properties.getProperty(name, null)
-}
+}.getOrNull()
 
 val benchmarkingInput = local("benchmarking.input")
 val graphRepoUrl = local("benchmarking.graph.url")


### PR DESCRIPTION
Fixed the build script failing during the configuration phase when no local.properties file exists; now, all values default to `null` instead