### PR TITLE
GitHub action improvements

### DIFF
--- a/.github/workflows/doc-release.yaml
+++ b/.github/workflows/doc-release.yaml
@@ -2,8 +2,6 @@ name: Publish documentation for release to Github Pages
 on:
   release:
     types: [published]
-env:
-  TARGET: release
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -15,6 +13,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Setup Gradle 8.12
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.12' # Quotes required to prevent YAML converting to number
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 
@@ -22,7 +25,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Generate documentation for release
-        run: ./gradlew --no-daemon :dokkaHtmlMultiModule
+        run: gradle --no-daemon :dokkaHtmlMultiModule
 
       - name: Publish documentation for release
         uses: JamesIves/github-pages-deploy-action@v4.4.0

--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -1,7 +1,7 @@
 name: Publish package to the Maven Central Repository
 on:
   release:
-    types: [created]
+    types: [published]
 env:
   TARGET: release
 jobs:
@@ -15,11 +15,16 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      - name: Setup Gradle 8.12
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.12' # Quotes required to prevent YAML converting to number
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
       - name: Publish to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        run: gradle --no-daemon publishAllPublicationsToMavenCentralRepository


### PR DESCRIPTION
Changed the publish action trigger type to be during release publishing, as this behaves more consistently
Added the Android SDK configure task to the publish action
Added Gradle configure task with correct version, using that gradle install for the gradle execution