### PR TITLE
Android library variant based on version type

### DIFF
--- a/buildSrc/src/main/kotlin/android-target.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-target.gradle.kts
@@ -12,7 +12,14 @@ repositories {
 kotlin {
     // target configuration
     androidTarget {
-        publishLibraryVariants("release", "debug")
+        when {
+            (version as String).endsWith("-SNAPSHOT") -> {
+                publishLibraryVariants("debug")
+            }
+            else -> {
+                publishLibraryVariants("release")
+            }
+        }
     }
 
     // source set configuration


### PR DESCRIPTION
Changed the Android target configuration to mark either debug or release as the publish variant for the library modules based on the version code; SNAPSHOT versions only have the debug variant, whilst regular releases have the release variant published