### PR TITLE
Various build fixes

### DIFF
--- a/.github/workflows/doc-release.yaml
+++ b/.github/workflows/doc-release.yaml
@@ -13,10 +13,10 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Setup Gradle 8.12
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.12' # Quotes required to prevent YAML converting to number
+          gradle-version: 'wrapper'
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -25,7 +25,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Generate documentation for release
-        run: gradle --no-daemon :dokkaHtmlMultiModule
+        run: ./gradlew --no-daemon :dokkaHtmlMultiModule
 
       - name: Publish documentation for release
         uses: JamesIves/github-pages-deploy-action@v4.4.0

--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -15,10 +15,10 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Setup Gradle 8.12
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.12' # Quotes required to prevent YAML converting to number
+          gradle-version: 'wrapper'
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -27,4 +27,4 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        run: gradle --no-daemon publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew --no-daemon publishAndReleaseToMavenCentral

--- a/buildSrc/src/main/kotlin/LocalProperties.kt
+++ b/buildSrc/src/main/kotlin/LocalProperties.kt
@@ -1,0 +1,16 @@
+
+import org.gradle.api.Project
+import java.io.File
+import java.util.*
+
+fun Project.local(name: String): String? =
+    runCatching {
+        val properties = Properties()
+        properties.load(File(rootDir.absolutePath + "/local.properties").inputStream())
+        return properties.getProperty(name, null)
+    }.getOrNull()
+
+fun Project.hasEnabled(name: String): Boolean {
+    val value = local(name)?.lowercase() ?: return false
+    return value in setOf("true", "enabled")
+}

--- a/buildSrc/src/main/kotlin/js-package.gradle.kts
+++ b/buildSrc/src/main/kotlin/js-package.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             name = "${parent.name}-$name"
             parent = parent.parent?.takeIf { it != project.rootProject }
         }
+        moduleName = name
         val npmPackageName = "@${project.findProperty("NPM_ORGANISATION")}/${name}"
         compilations.forEach { compilation ->
             // setting the outputModuleName to the entire name value (= incl. the scope) yields
@@ -40,7 +41,7 @@ kotlin {
             compilation.packageJson {
                 customField("name", npmPackageName)
             }
-            compilation.target.outputModuleName.set(name)
+            compilation.outputModuleName = name
         }
         println("Configured NPM package $npmPackageName")
         nodejs()

--- a/gradle/libraries.versions.toml
+++ b/gradle/libraries.versions.toml
@@ -2,7 +2,7 @@
 
 compileSdk = "35"
 android-plugin = "8.9.1"
-kotlin = "2.1.20"
+kotlin = "2.1.10"
 maven-publish = "0.31.0"
 
 [libraries]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,23 @@
+import java.util.*
+
 apply(from = "./buildSrc/settings.gradle.kts")
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
+}
+
+/* helpers (see below) */
+
+fun Settings.local(name: String): String? =
+    runCatching {
+        val properties = Properties()
+        properties.load(File(rootDir.absolutePath + "/local.properties").inputStream())
+        return properties.getProperty(name, null)
+    }.getOrNull()
+
+fun Settings.hasEnabled(name: String): Boolean {
+    val value = local(name)?.lowercase() ?: return false
+    return value in setOf("true", "enabled")
 }
 
 rootProject.name = "tesserakt"
@@ -46,10 +62,19 @@ include("testing:bench:microbench")
 
 include("testing:bench:sparql")
 include("testing:bench:sparql:core")
-include("testing:bench:sparql:ref:blazegraph")
-include("testing:bench:sparql:ref:comunica")
-include("testing:bench:sparql:ref:jena")
-include("testing:bench:sparql:ref:rdfox")
+
+if (hasEnabled("bench.sparql.blazegraph")) {
+    include("testing:bench:sparql:ref:blazegraph")
+}
+if (hasEnabled("bench.sparql.jena")) {
+    include("testing:bench:sparql:ref:jena")
+}
+if (hasEnabled("bench.sparql.rdfox")) {
+    include("testing:bench:sparql:ref:rdfox")
+}
+if (hasEnabled("bench.sparql.comunica")) {
+    include("testing:bench:sparql:ref:comunica")
+}
 
 include("testing:tooling:environment")
 include("testing:tooling:replay-benchmark")

--- a/testing/bench/sparql/build.gradle.kts
+++ b/testing/bench/sparql/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalMainFunctionArgumentsDsl
-import java.util.*
 
 plugins {
     // not distributed as a package, build targets are manually defined
@@ -36,28 +35,29 @@ kotlin {
                 implementation(kotlin("reflect"))
                 // further used in the reflection implementation to detect all reference implementations
                 implementation("com.google.guava:guava:33.4.6-jre")
-                // TODO: properties-based
-                implementation(project(":testing:bench:sparql:ref:blazegraph"))
-                implementation(project(":testing:bench:sparql:ref:jena"))
-//                implementation(project(":testing:bench:sparql:ref:rdfox"))
+                if (project.hasEnabled("bench.sparql.blazegraph")) {
+                    implementation(project(":testing:bench:sparql:ref:blazegraph"))
+                }
+                if (project.hasEnabled("bench.sparql.jena")) {
+                    implementation(project(":testing:bench:sparql:ref:jena"))
+                }
+                if (project.hasEnabled("bench.sparql.rdfox")) {
+                    implementation(project(":testing:bench:sparql:ref:rdfox"))
+                }
             }
         }
         val jsMain by getting {
             dependencies {
-                implementation(project(":testing:bench:sparql:ref:comunica"))
+                if (project.hasEnabled("bench.sparql.comunica")) {
+                    implementation(project(":testing:bench:sparql:ref:comunica"))
+                }
             }
         }
     }
 }
 
-fun local(name: String): String? = runCatching {
-    val properties = Properties()
-    properties.load(File(rootDir.absolutePath + "/local.properties").inputStream())
-    return properties.getProperty(name, null)
-}.getOrNull()
-
-val benchmarkingInput = local("benchmarking.input")
-val graphRepoUrl = local("benchmarking.graph.url")
+val benchmarkingInput = project.local("benchmarking.input")
+val graphRepoUrl = project.local("benchmarking.graph.url")
 val benchmarkingEnabled = benchmarkingInput != null && File(benchmarkingInput).exists()
 
 val build = layout.buildDirectory

--- a/testing/bench/sparql/src/jsMain/kotlin/dev/tesserakt/benchmarking/Evaluator.js.kt
+++ b/testing/bench/sparql/src/jsMain/kotlin/dev/tesserakt/benchmarking/Evaluator.js.kt
@@ -1,5 +1,4 @@
 package dev.tesserakt.benchmarking
 
-actual val references: Map<String, (String) -> Reference> = mapOf(
-    "comunica" to { ComunicaReference(it) }
-)
+// TODO: make this reference a property generated at build time based on the configuration
+actual val references: Map<String, (String) -> Reference> = mapOf()


### PR DESCRIPTION
Reverted back to Kotlin 2.1.10, as 2.1.20 with the updated JS Gradle setup broke the `kotlinNpmInstall` task, reporting duplicate workspace names
Improved the use of local properties, making them more generally available through the convention plugins, alongside a helper to detect when a config item is enabled
Made all reference implementations used in the sparql bench optional, configurable through local properties, and disabled by default
Gradle - actions improvements