### PR TITLE
Enabled Maven package signing on release

### DIFF
--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -27,4 +27,5 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        run: ./gradlew --no-daemon publishAndReleaseToMavenCentral "-Dorg.gradle.jvmargs=-Xms1g -Xmx4g"
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: ./gradlew --no-daemon publishAndReleaseToMavenCentral --no-configuration-cache "-Dorg.gradle.jvmargs=-Xms1g -Xmx4g"

--- a/buildSrc/src/main/kotlin/mvn-package.gradle.kts
+++ b/buildSrc/src/main/kotlin/mvn-package.gradle.kts
@@ -29,6 +29,10 @@ mavenPublishing {
         }
     }
 
+    if (!(version as String).endsWith("-SNAPSHOT")) {
+        signAllPublications()
+    }
+
     println("Configured Maven package ${project.property("MAVEN_CENTRAL_GROUP_ID") as String}:tesserakt-${artifactId}:${project.version as String}")
 }
 


### PR DESCRIPTION
Configured the Maven publishing plugin to sign packages on release with the environment variable GPG key
Added the `--no-configuration-cache` flag whilst releasing, even though this cache is currently globally not enabled