### PR TITLE
Maven publishing fixes

### DIFF
--- a/buildSrc/src/main/kotlin/mvn-package.gradle.kts
+++ b/buildSrc/src/main/kotlin/mvn-package.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
@@ -8,10 +10,26 @@ plugins {
 mavenPublishing {
     val artifactId = getArtifactId()
     coordinates(project.property("MAVEN_CENTRAL_GROUP_ID") as String, "tesserakt-$artifactId", version = project.version as String)
+
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // src: https://vanniktech.github.io/gradle-maven-publish-plugin/what/
+    configure(KotlinMultiplatform(
+        // configures the -javadoc artifact, possible values:
+        // - `JavadocJar.None()` don't publish this artifact
+        // - `JavadocJar.Empty()` publish an emprt jar
+        // - `JavadocJar.Javadoc()` to publish standard javadocs
+        javadocJar = JavadocJar.Empty(),
+        // whether to publish a sources jar
+        sourcesJar = true,
+        // configure which Android library variants to publish if this project has an Android target
+        // defaults to "release" when using the main plugin and nothing for the base plugin
+        androidVariantsToPublish = if ((version as String).endsWith("-SNAPSHOT")) listOf("debug") else listOf("release"),
+    ))
 
     pom {
         name.set("tesserakt ($artifactId)")
+        description.set(project.property("POM_DESCRIPTION") as String)
         inceptionYear.set("2023")
         url.set(project.property("GIT_URL") as String)
         licenses {
@@ -26,6 +44,11 @@ mavenPublishing {
                 name.set("Tom Windels")
                 url.set("https://github.com/TomWindels/")
             }
+        }
+        scm {
+            url.set(project.property("POM_SCM_URL") as String)
+            connection.set(project.property("POM_SCM_CONNECTION") as String)
+            developerConnection.set(project.property("POM_SCM_DEV_CONNECTION") as String)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,11 @@ VERSION_NAME=0.1.0
 
 NPM_ORGANISATION=tesseraktjs
 MAVEN_CENTRAL_GROUP_ID=io.github.tomwindels
-GIT_URL=https://github.com/tomwindels/tesserakt
+GIT_URL=https://github.com/TomWindels/tesserakt
+POM_SCM_URL=https://github.com/TomWindels/tesserakt/
+POM_SCM_CONNECTION=scm:git:git://github.com/TomWindels/tesserakt.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/TomWindels/tesserakt.git
+POM_DESCRIPTION=A Kotlin Multiplatform library RDF & SPARQL applications
 
 kotlin.code.style=official
 kotlin.mpp.applyDefaultHierarchyTemplate=false


### PR DESCRIPTION
Added additional properties to the generated POM file to satisfy the Maven Central requirements; this now includes a general project description, SCM configuration, and (empty!) javadocs to be present for every release