### PR TITLE
JDK 8 configuration

### DIFF
--- a/buildSrc/src/main/kotlin/android-target.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-target.gradle.kts
@@ -27,8 +27,9 @@ kotlin {
         }
         lint {
             abortOnError = true
-            enable += "NewApi"
-            fatal += "NewApi"
+            enable += listOf("NewApi", "InvalidPackage", "NewerVersionAvailable", "NoOp", "StopShip", "SyntheticAccessor")
+            warning += listOf("StopShip")
+            fatal += listOf("NewApi", "InvalidPackage")
         }
         println("Configured Android Library $namespace")
     }

--- a/buildSrc/src/main/kotlin/android-target.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-target.gradle.kts
@@ -35,12 +35,6 @@ android {
     compileSdk = libs.get("compileSdk").toInt()
     namespace = getNamespace()
     println("Configured Android Library $namespace")
-    compileOptions {
-        // removeFirst was only added to java.util.List in JDK 21
-        // https://github.com/javalin/javalin/issues/2117#issuecomment-1960114620
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
 }
 
 fun getNamespace(): String {

--- a/buildSrc/src/main/kotlin/jvm-target.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-target.gradle.kts
@@ -26,10 +26,6 @@ kotlin {
     }
 }
 
-// preventing `NoSuchMethodException`s from occurring when dealing with Compile SDK 35 and above on Android when
-//  using extension functions such as `MutableList::removeFirst()`
-// src: https://jakewharton.com/kotlins-jdk-release-compatibility-flag/
-
 tasks.withType(JavaCompile::class.java).configureEach {
     sourceCompatibility = JavaVersion.VERSION_1_8.name
     targetCompatibility = JavaVersion.VERSION_1_8.name
@@ -37,5 +33,6 @@ tasks.withType(JavaCompile::class.java).configureEach {
 
 tasks.withType(KotlinJvmCompile::class.java).configureEach {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    // src: https://jakewharton.com/kotlins-jdk-release-compatibility-flag/
     compilerOptions.freeCompilerArgs.add("-Xjdk-release=1.8")
 }

--- a/buildSrc/src/main/kotlin/jvm-target.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-target.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 plugins {
     id("base-config")
 }
@@ -21,4 +24,18 @@ kotlin {
         jvmMain.get().dependsOn(commonJvmMain)
         // in case of an android target, this can now also depend on the `commonJvmMain` sourceset
     }
+}
+
+// preventing `NoSuchMethodException`s from occurring when dealing with Compile SDK 35 and above on Android when
+//  using extension functions such as `MutableList::removeFirst()`
+// src: https://jakewharton.com/kotlins-jdk-release-compatibility-flag/
+
+tasks.withType(JavaCompile::class.java).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_1_8.name
+    targetCompatibility = JavaVersion.VERSION_1_8.name
+}
+
+tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    compilerOptions.freeCompilerArgs.add("-Xjdk-release=1.8")
 }

--- a/serialization/n3/src/commonMain/kotlin/dev/tesserakt/rdf/n3/serialization/Formatter.kt
+++ b/serialization/n3/src/commonMain/kotlin/dev/tesserakt/rdf/n3/serialization/Formatter.kt
@@ -1,6 +1,8 @@
 package dev.tesserakt.rdf.n3.serialization
 
 import dev.tesserakt.util.addFront
+import dev.tesserakt.util.removeFirstElement
+import dev.tesserakt.util.removeLastElement
 import kotlin.jvm.JvmInline
 
 
@@ -65,7 +67,7 @@ data class PrettyFormatter(
         fun advance(): Boolean {
             current = next ?: return false
             next = when {
-                buf.isNotEmpty() -> buf.removeFirst()
+                buf.isNotEmpty() -> buf.removeFirstElement()
                 iterator.hasNext() -> iterator.next()
                 else -> null
             }
@@ -160,7 +162,7 @@ data class PrettyFormatter(
 
         fun stopFrame() {
             check(frames.size > 1) { "Invalid frame termination request! Root frame cannot be removed!" }
-            frames.removeLast()
+            frames.removeLastElement()
         }
 
         override fun toString() = frames.joinToString(" => ")

--- a/serialization/trig/src/commonMain/kotlin/dev/tesserakt/rdf/trig/serialization/Formatter.kt
+++ b/serialization/trig/src/commonMain/kotlin/dev/tesserakt/rdf/trig/serialization/Formatter.kt
@@ -4,6 +4,7 @@ import dev.tesserakt.rdf.serialization.common.Prefixes
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
 import dev.tesserakt.util.addFront
 import dev.tesserakt.util.fit
+import dev.tesserakt.util.removeFirstElement
 import kotlin.jvm.JvmInline
 
 
@@ -73,7 +74,7 @@ data class PrettyFormatter(
         fun advance(): Boolean {
             current = next ?: return false
             next = when {
-                buf.isNotEmpty() -> buf.removeFirst()
+                buf.isNotEmpty() -> buf.removeFirstElement()
                 iterator.hasNext() -> iterator.next().mapped(prefixes)
                 else -> null
             }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
@@ -4,6 +4,7 @@ import dev.tesserakt.sparql.runtime.evaluation.*
 import dev.tesserakt.sparql.runtime.stream.OptimisedStream
 import dev.tesserakt.sparql.runtime.stream.emptyIterable
 import dev.tesserakt.sparql.util.Cardinality
+import dev.tesserakt.util.removeLastElement
 
 /**
  * An array useful for storing a series of mappings, capable of joining with other mappings using the hash join
@@ -156,14 +157,14 @@ class MultiHashMappingArray(
         var i = 0
         while (i < size - 1) {
             if (backing[i] == null) {
-                backing[i] = backing.removeLast()
+                backing[i] = backing.removeLastElement()
             } else {
                 ++i
             }
         }
         // trimming the end
         if (backing.isNotEmpty() && backing.last() == null) {
-            backing.removeLast()
+            backing.removeLastElement()
         }
         // resetting the hole count
         holes = 0

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/SimpleMappingArray.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/SimpleMappingArray.kt
@@ -3,6 +3,7 @@ package dev.tesserakt.sparql.runtime.collection
 import dev.tesserakt.sparql.runtime.evaluation.Mapping
 import dev.tesserakt.sparql.runtime.stream.CollectedStream
 import dev.tesserakt.sparql.util.Cardinality
+import dev.tesserakt.util.removeLastElement
 import kotlin.jvm.JvmInline
 
 @JvmInline
@@ -38,11 +39,11 @@ value class SimpleMappingArray(
                 throw IllegalStateException("$mapping cannot be removed from NestedJoinArray - not found!")
             }
             this.mappings.size - 1 -> {
-                this.mappings.removeLast()
+                this.mappings.removeLastElement()
             }
             else -> {
                 // putting the last element there instead
-                this.mappings[i] = this.mappings.removeLast()
+                this.mappings[i] = this.mappings.removeLastElement()
             }
         }
     }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
@@ -8,6 +8,7 @@ import dev.tesserakt.sparql.types.Union
 import dev.tesserakt.sparql.util.Bitmask
 import dev.tesserakt.sparql.util.Cardinality
 import dev.tesserakt.sparql.util.OneCardinality
+import dev.tesserakt.util.removeFirstElement
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmName
 
@@ -412,9 +413,9 @@ sealed interface JoinTree: MutableJoinState {
                 // TODO(perf): actually check individual states on overlapping bindings, have them be connected nodes,
                 //  with the total index list depending on the not-yet-inserted patterns
                 val remaining = states.mapTo(ArrayList(states.size)) { Node.Leaf(it) }
-                var result: Node<J> = Node.Disconnected(context = context, left = remaining.removeFirst(), right = remaining.removeFirst())
+                var result: Node<J> = Node.Disconnected(context = context, left = remaining.removeFirstElement(), right = remaining.removeFirstElement())
                 while (remaining.isNotEmpty()) {
-                    result = Node.Disconnected(context = context, left = result, right = remaining.removeFirst())
+                    result = Node.Disconnected(context = context, left = result, right = remaining.removeFirstElement())
                 }
                 return result
             }

--- a/utils/src/androidMain/kotlin/dev/tesserakt/util/CollectionExtensions.android.kt
+++ b/utils/src/androidMain/kotlin/dev/tesserakt/util/CollectionExtensions.android.kt
@@ -1,6 +1,11 @@
 package dev.tesserakt.util
 
+/**
+ * Replaces the value associated with [key] with the value computed by [transform]ing the original value (if any)
+ */
 actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
+    // the `compute` method is only available since Android SDK 24; as we currently have no `minSdk` configured for all
+    //  Android modules, we should fall back on this approach instead
     this[key] = transform(this[key])
 }
 
@@ -9,7 +14,7 @@ actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform:
  *  Android 14 and below
  */
 actual inline fun <T> MutableList<T>.removeFirstElement(): T {
-    return removeFirst()
+    return removeAt(0)
 }
 
 /**
@@ -17,5 +22,5 @@ actual inline fun <T> MutableList<T>.removeFirstElement(): T {
  *  Android 14 and below
  */
 actual inline fun <T> MutableList<T>.removeLastElement(): T {
-    return removeLast()
+    return removeAt(size - 1)
 }

--- a/utils/src/commonJvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.jvm.kt
+++ b/utils/src/commonJvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.jvm.kt
@@ -1,8 +1,0 @@
-package dev.tesserakt.util
-
-/**
- * Replaces the value associated with [key] with the value computed by [transform]ing the original value (if any)
- */
-actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
-    compute(key) { _, v -> transform(v) }
-}

--- a/utils/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
+++ b/utils/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
@@ -147,10 +147,10 @@ inline fun <T> MutableList<T>.unorderedDropAt(index: Int) {
             clear()
         }
         index == size - 1 -> {
-            removeLast()
+            removeLastElement()
         }
         else -> {
-            this[index] = removeLast()
+            this[index] = removeLastElement()
         }
     }
 }
@@ -161,3 +161,15 @@ inline fun <K, V: Any> Iterable<K>.associateWithNotNull(transform: (K) -> V?): M
         put(key, value)
     }
 }
+
+/**
+ * A custom implementation of the [MutableList.removeFirst] method, implemented to make sure it resolves properly on
+ *  Android 14 and below
+ */
+expect inline fun <T> MutableList<T>.removeFirstElement(): T
+
+/**
+ * A custom implementation of the [MutableList.removeLast] method, implemented to make sure it resolves properly on
+ *  Android 14 and below
+ */
+expect inline fun <T> MutableList<T>.removeLastElement(): T

--- a/utils/src/jvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.jvm.kt
+++ b/utils/src/jvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.jvm.kt
@@ -1,7 +1,10 @@
 package dev.tesserakt.util
 
+/**
+ * Replaces the value associated with [key] with the value computed by [transform]ing the original value (if any)
+ */
 actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
-    this[key] = transform(this[key])
+    compute(key) { _, v -> transform(v) }
 }
 
 /**

--- a/utils/src/nativeMain/kotlin/dev/tesserakt/util/CollectionExtensions.native.kt
+++ b/utils/src/nativeMain/kotlin/dev/tesserakt/util/CollectionExtensions.native.kt
@@ -3,3 +3,19 @@ package dev.tesserakt.util
 actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
     this[key] = transform(this[key])
 }
+
+/**
+ * A custom implementation of the [MutableList.removeFirst] method, implemented to make sure it resolves properly on
+ *  Android 14 and below
+ */
+actual inline fun <T> MutableList<T>.removeFirstElement(): T {
+    return removeFirst()
+}
+
+/**
+ * A custom implementation of the [MutableList.removeLast] method, implemented to make sure it resolves properly on
+ *  Android 14 and below
+ */
+actual inline fun <T> MutableList<T>.removeLastElement(): T {
+    return removeLast()
+}


### PR DESCRIPTION
Changed the Gradle build scripts for modules targeting the JVM, configuring these modules to use JDK 8 instead of 21 (JDK 21 did not resolve the original issue).
An additional compiler argument was added instead to resolve the issue related to missing methods when targeting a higher compile SDK

Resolves #45 