### PR TITLE
RDFox reference evaluator implementation fixes

### DIFF
--- a/testing/bench/sparql/ref/rdfox/src/jvmMain/kotlin/dev/tesserakt/benchmarking/RDFoxReference.kt
+++ b/testing/bench/sparql/ref/rdfox/src/jvmMain/kotlin/dev/tesserakt/benchmarking/RDFoxReference.kt
@@ -1,33 +1,25 @@
 package dev.tesserakt.benchmarking
 
+import dev.tesserakt.rdf.trig.serialization.SimpleFormatter
 import dev.tesserakt.rdf.trig.serialization.TriGSerializer
 import dev.tesserakt.rdf.types.SnapshotStore
 import tech.oxfordsemantic.jrdfox.Prefixes
-import tech.oxfordsemantic.jrdfox.client.QueryAnswerMonitor
-import tech.oxfordsemantic.jrdfox.client.RDFoxServer
-import tech.oxfordsemantic.jrdfox.client.ResourceValue
-import tech.oxfordsemantic.jrdfox.client.UpdateType
+import tech.oxfordsemantic.jrdfox.client.*
 import tech.oxfordsemantic.jrdfox.logic.expression.BlankNode
 import tech.oxfordsemantic.jrdfox.logic.expression.IRI
 import tech.oxfordsemantic.jrdfox.logic.expression.Literal
+import java.io.InputStream
 
 class RDFoxReference(private val query: String) : Reference() {
-
-    private val connection = RDFoxServer.newServerConnection("guest", "guest")
     private var previous = emptyList<MutableList<ResourceValue>>()
     private var current = mutableListOf<MutableList<ResourceValue>>()
 
     private var checksum = 0
 
-    init {
-        connection.createDataStore("data", emptyMap())
-        connection.numberOfThreads = 1
-    }
-
     override fun prepare(diff: SnapshotStore.Diff) {
         connection.newDataStoreConnection("data").use { conn ->
-            conn.importData(UpdateType.ADDITION, TriGSerializer.serialize(diff.insertions))
-            conn.importData(UpdateType.DELETION, TriGSerializer.serialize(diff.deletions))
+            conn.importData(UpdateType.ADDITION, TriGSerializer.serialize(diff.insertions, SimpleFormatter).toInputStream())
+            conn.importData(UpdateType.DELETION, TriGSerializer.serialize(diff.deletions, SimpleFormatter).toInputStream())
         }
     }
 
@@ -62,9 +54,20 @@ class RDFoxReference(private val query: String) : Reference() {
     }
 
     override fun close() {
-        connection.close()
+        connection.newDataStoreConnection("data").use { conn ->
+            conn.clear(DataStorePart.FACTS)
+        }
     }
 
+}
+
+// creating a single connection, making sure it's only configured once upon first use
+private val connection by lazy {
+    RDFoxServer.newServerConnection("guest", "guest")
+        .apply {
+            createDataStore("data", emptyMap())
+            numberOfThreads = 1
+        }
 }
 
 private val ResourceValue.checksumValue: Int
@@ -78,11 +81,9 @@ private val ResourceValue.checksumValue: Int
         }
 
         is Literal -> {
+            // the lexical form is already the contents inside the `""` notation, e.g. `"true"^^xsd:boolean` has lexical form `true`
             val str = r.lexicalForm
-            require(str.startsWith('"')) {
-                "Unexpected lexical form for a literal encountered: got `${str}`, expected `\"value\"^^<type>`"
-            }
-            str.indexOf('"', 2) - 1
+            str.length
         }
 
         is IRI -> {
@@ -93,3 +94,24 @@ private val ResourceValue.checksumValue: Int
             throw IllegalStateException("Unexpected resource type `${r::class.simpleName}` encountered!")
         }
     }
+
+private fun Iterator<String>.toInputStream(): InputStream = object: InputStream() {
+
+    private val src = this@toInputStream
+    private var current = if (src.hasNext()) src.next().encodeToByteArray() else byteArrayOf()
+    private var i = 0
+
+    override fun read(): Int {
+        return when {
+            i < current.size -> {
+                current[i++].toInt()
+            }
+            src.hasNext() -> {
+                i = 0
+                current = src.next().encodeToByteArray()
+                read()
+            }
+            else -> -1
+        }
+    }
+}


### PR DESCRIPTION
Moved the connection and store initialization to a lazily-evaluated reused instance, as otherwise subsequent runs fail
Fixed the checksum value generated from RDFox literals
Changed the serialization strategy when inserting triples to use simple formatting and use an InputStream type instead of an entire string object to process changes more efficiently