### PR TITLE
Duplicate binding use in Triple Patterns

### DIFF
--- a/sparql/validator/src/commonMain/kotlin/Main.kt
+++ b/sparql/validator/src/commonMain/kotlin/Main.kt
@@ -7,26 +7,22 @@ suspend fun run(args: Array<String>) {
     when (args.size) {
         0 -> {
             println("Running built-in tests")
-            val one = compareIncrementalChainSelectOutput(seed = 1)
-                .test(QueryExecutionTestValues::toOutputComparisonTest)
-                .run()
-            val two = compareIncrementalStarSelectOutput(seed = 1)
-                .test(QueryExecutionTestValues::toOutputComparisonTest)
-                .run()
-            val three = builtinTests()
-                .test(QueryExecutionTestValues::toOutputComparisonTest)
-                .run()
-            val four = builtinTests()
-                .test(QueryExecutionTestValues::toIncrementalUpdateTest)
-                .run()
-            val five = builtinTests()
-                .test(QueryExecutionTestValues::toRandomUpdateTest)
-                .run()
-            one.report()
-            two.report()
-            three.report()
-            four.report()
-            five.report()
+            val results = listOf(
+                compareIncrementalChainSelectOutput(seed = 1)
+                    .test(QueryExecutionTestValues::toOutputComparisonTest),
+                compareIncrementalStarSelectOutput(seed = 1)
+                    .test(QueryExecutionTestValues::toOutputComparisonTest),
+                builtinTests()
+                    .test(QueryExecutionTestValues::toOutputComparisonTest),
+                builtinTests()
+                    .test(QueryExecutionTestValues::toIncrementalUpdateTest),
+                builtinTests()
+                    .test(QueryExecutionTestValues::toRandomUpdateTest),
+            ).map { it.run() }
+            results.forEach { it.report() }
+            if (results.any { !it.isSuccess() }) {
+                throw IllegalStateException("Not all tests succeeded!")
+            }
         }
         1 -> {
             val (replayBenchmarkPath) = args

--- a/sparql/validator/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/sparql/validator/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -42,6 +42,12 @@ fun builtinTests() = tests {
 
     using(small) test """
         SELECT * {
+            ?s (<http://example.org/path1>|<http://example.org/path2>) ?s
+        }
+    """
+
+    using(small) test """
+        SELECT * {
             ?s (<http://example.org/path1>/!<http://example.org/path2>) ?o
         }
     """
@@ -548,6 +554,12 @@ fun builtinTests() = tests {
 
     using(fullyConnected) test """
         SELECT * WHERE {
+            ?a <http://example.org/p>* ?a
+        }
+    """
+
+    using(fullyConnected) test """
+        SELECT * WHERE {
             ?a (<http://example.org/p>/<http://example.org/p>/<http://example.org/p>)* <http://example.org/b>
         }
     """
@@ -657,6 +669,13 @@ fun builtinTests() = tests {
         PREFIX : <http://www.example.org/>
         SELECT ?s WHERE {
             :a (:p1|:p2)/(:p3|:p4) ?s
+        }
+    """
+
+    using(unions) test """
+        PREFIX : <http://www.example.org/>
+        SELECT ?s WHERE {
+            ?s (:p1|:p2)/(:p3|:p4) ?s
         }
     """
 

--- a/sparql/validator/src/commonMain/kotlin/sparql/tests/Tests.kt
+++ b/sparql/validator/src/commonMain/kotlin/sparql/tests/Tests.kt
@@ -48,6 +48,12 @@ fun builtinTests() = tests {
 
     using(small) test """
         SELECT * {
+            ?s ?s ?s
+        }
+    """
+
+    using(small) test """
+        SELECT * {
             ?s (<http://example.org/path1>/!<http://example.org/path2>) ?o
         }
     """

--- a/testing/tooling/environment/src/commonMain/kotlin/dev/tesserakt/testing/TestEnvironment.kt
+++ b/testing/tooling/environment/src/commonMain/kotlin/dev/tesserakt/testing/TestEnvironment.kt
@@ -45,6 +45,10 @@ class TestEnvironment {
             }
         }
 
+        fun isSuccess(): Boolean {
+            return results.all { (_, result) -> result is Test.Result.Skipped || result.isSuccess() }
+        }
+
     }
 
     suspend fun run(count: Int = 1) = Results(


### PR DESCRIPTION
Repeating bindings in triple patterns can cause unexpected (incorrect) results. This MR addresses this behaviour, along new tests that now succeed