### PR TITLE
Kotlin/WASM support

### DIFF
--- a/buildSrc/src/main/kotlin/kmp-package.gradle.kts
+++ b/buildSrc/src/main/kotlin/kmp-package.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("js-package")
+    id("wasm-js-target")
     id("jvm-target")
     id("android-target")
     id("native-target")

--- a/buildSrc/src/main/kotlin/wasm-js-target.gradle.kts
+++ b/buildSrc/src/main/kotlin/wasm-js-target.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("base-config")
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    // target configuration
+    wasmJs {
+        nodejs()
+        browser()
+    }
+}

--- a/serialization/core/src/wasmJsMain/kotlin/dev/tesserakt/rdf/serialization/util/BufferedReader.wasmJs.kt
+++ b/serialization/core/src/wasmJsMain/kotlin/dev/tesserakt/rdf/serialization/util/BufferedReader.wasmJs.kt
@@ -1,0 +1,31 @@
+package dev.tesserakt.rdf.serialization.util
+
+actual class BufferedReader(private val content: String) : AutoCloseable {
+
+    private var pos = 0
+
+    actual override fun close() {
+        // nothing to do
+    }
+
+    internal fun read(count: Int): String? {
+        if (pos >= content.length) {
+            return null
+        }
+        val result = content.substring(pos, (pos + count).coerceAtMost(content.length))
+        pos += count
+        return result
+    }
+
+}
+
+actual fun BufferedReader.read(count: Int): String? {
+    return read(count)
+}
+
+actual fun String.openAsBufferedReader(): Result<BufferedReader> =
+    Result.failure(UnsupportedOperationException("The WASM implementation currently has no filesystem integration"))
+
+actual fun String.wrapAsBufferedReader(): BufferedReader {
+    return BufferedReader(content = this)
+}

--- a/utils/src/wasmJsMain/kotlin/dev/tesserakt/util/CollectionExtensions.wasmJs.kt
+++ b/utils/src/wasmJsMain/kotlin/dev/tesserakt/util/CollectionExtensions.wasmJs.kt
@@ -1,0 +1,21 @@
+package dev.tesserakt.util
+
+actual inline fun <K, V> MutableMap<K, V>.replace(key: K, crossinline transform: (V?) -> V) {
+    this[key] = transform(this[key])
+}
+
+/**
+ * A custom implementation of the [MutableList.removeFirst] method, implemented to make sure it resolves properly on
+ *  Android 14 and below
+ */
+actual inline fun <T> MutableList<T>.removeFirstElement(): T {
+    return removeFirst()
+}
+
+/**
+ * A custom implementation of the [MutableList.removeLast] method, implemented to make sure it resolves properly on
+ *  Android 14 and below
+ */
+actual inline fun <T> MutableList<T>.removeLastElement(): T {
+    return removeLast()
+}

--- a/utils/src/wasmJsMain/kotlin/dev/tesserakt/util/Logging.wasmJs.kt
+++ b/utils/src/wasmJsMain/kotlin/dev/tesserakt/util/Logging.wasmJs.kt
@@ -1,0 +1,5 @@
+package dev.tesserakt.util
+
+actual fun printerrln(message: String) {
+    js("{ console.error(message); }")
+}


### PR DESCRIPTION
The KMP package convention plugin has been expanded to also include WASM build support, so Kotlin projects targeting WASM (js) can also use these modules as dependencies

Fixes #56 