### PR TITLE
Testing improvements

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         run: ./gradlew lint
 
       - name: Executing tests
-        run: ./gradlew test
+        run: ./gradlew allTests
 
   publish-release-maven:
     name: "Publish to Maven Central"

--- a/buildSrc/src/main/kotlin/SnapshotVersion.kt
+++ b/buildSrc/src/main/kotlin/SnapshotVersion.kt
@@ -1,0 +1,4 @@
+import org.gradle.api.Project
+
+val Project.SNAPSHOT: Boolean
+    get() = (version as String).endsWith("-SNAPSHOT")

--- a/buildSrc/src/main/kotlin/js-package.gradle.kts
+++ b/buildSrc/src/main/kotlin/js-package.gradle.kts
@@ -47,6 +47,15 @@ kotlin {
         nodejs()
         generateTypeScriptDefinitions()
         binaries.library()
+
+        // snapshot releases should not have minimised member names to help with debugging
+        if (SNAPSHOT) {
+            compilations.all {
+                compileTaskProvider.configure {
+                    compilerOptions.freeCompilerArgs.add("-Xir-minimized-member-names=false")
+                }
+            }
+        }
     }
 
     // no custom source set configuration

--- a/buildSrc/src/main/kotlin/js-package.gradle.kts
+++ b/buildSrc/src/main/kotlin/js-package.gradle.kts
@@ -33,15 +33,23 @@ kotlin {
         }
         moduleName = name
         val npmPackageName = "@${project.findProperty("NPM_ORGANISATION")}/${name}"
-        compilations.forEach { compilation ->
-            // setting the outputModuleName to the entire name value (= incl. the scope) yields
-            //  runtime exceptions, so that approach is avoided
-            // src for this approach:
-            // https://youtrack.jetbrains.com/issue/KT-25878/Provide-Option-to-Define-Scoped-NPM-Package#focus=Comments-27-6742844.0-0
-            compilation.packageJson {
+        // setting the outputModuleName to the entire name value (= incl. the scope) yields
+        //  runtime exceptions, so that approach is avoided
+        // src for this approach:
+        // https://youtrack.jetbrains.com/issue/KT-25878/Provide-Option-to-Define-Scoped-NPM-Package#focus=Comments-27-6742844.0-0
+        // targeting the main and test compilation target separately, so there is no name collisions when building
+        //  the module & its tests
+        compilations.named("main") {
+            packageJson {
                 customField("name", npmPackageName)
             }
-            compilation.outputModuleName = name
+            outputModuleName = name
+        }
+        compilations.named("test") {
+            packageJson {
+                customField("name", "${npmPackageName}-test")
+            }
+            outputModuleName = "${name}-test"
         }
         println("Configured NPM package $npmPackageName")
         nodejs()

--- a/buildSrc/src/main/kotlin/mvn-package.gradle.kts
+++ b/buildSrc/src/main/kotlin/mvn-package.gradle.kts
@@ -24,7 +24,7 @@ mavenPublishing {
         sourcesJar = true,
         // configure which Android library variants to publish if this project has an Android target
         // defaults to "release" when using the main plugin and nothing for the base plugin
-        androidVariantsToPublish = if ((version as String).endsWith("-SNAPSHOT")) listOf("debug") else listOf("release"),
+        androidVariantsToPublish = if (SNAPSHOT) listOf("debug") else listOf("release"),
     ))
 
     pom {
@@ -52,7 +52,7 @@ mavenPublishing {
         }
     }
 
-    if (!(version as String).endsWith("-SNAPSHOT")) {
+    if (!SNAPSHOT) {
         signAllPublications()
     }
 

--- a/buildSrc/src/main/kotlin/wasm-js-target.gradle.kts
+++ b/buildSrc/src/main/kotlin/wasm-js-target.gradle.kts
@@ -10,6 +10,12 @@ kotlin {
     // target configuration
     wasmJs {
         nodejs()
-        browser()
+        browser {
+            testTask {
+                // we cannot guarantee every system has the same set of browsers available, so the browser target
+                //  should not be tested
+                enabled = false
+            }
+        }
     }
 }

--- a/testing/tooling/environment/build.gradle.kts
+++ b/testing/tooling/environment/build.gradle.kts
@@ -1,17 +1,16 @@
 plugins {
-    // not distributed as a package
-    id("base-config")
+    // not distributed as a package, but reusing the target platform conventions/configurations
+    id("jvm-target")
+    id("native-target")
 }
 
 group = "testing"
 
 kotlin {
-    jvm()
     js {
         nodejs()
     }
-    mingwX64()
-    linuxX64()
+    // jvm and native are already configured through the convention plugins
     sourceSets {
         // core modules tested by all test targets
         val commonMain by getting {


### PR DESCRIPTION
Improved the testing setup, by executing the `allTests` task responsible for executing tests on the various target platforms instead
Added a "SNAPSHOT" property to the Gradle `Project` type, acting as a helper check to enable SNAPSHOT-only build properties (instead of doing a string check)
Disabled JS member minimisation on snapshot compilation
Improved the build script for the testing environment module, applying the same JVM config, ensuring a correct JDK version is being used
Disabled the WasmJs browser tests that would otherwise fail to execute when running `allTests`

NOTE: with this change, the new testing task *FAILS*! Subsequent commits in other branches targeting the new release address these test failures