### PR TITLE
Public base SPARQL exception type

### DIFF
--- a/sparql/common/src/commonMain/kotlin/dev/tesserakt/sparql/SparqlException.kt
+++ b/sparql/common/src/commonMain/kotlin/dev/tesserakt/sparql/SparqlException.kt
@@ -1,0 +1,3 @@
+package dev.tesserakt.sparql
+
+abstract class SparqlException(message: String?): RuntimeException(message)

--- a/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/CompilerException.kt
+++ b/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/CompilerException.kt
@@ -1,10 +1,12 @@
 package dev.tesserakt.sparql.compiler
 
-class CompilerError(
+import dev.tesserakt.sparql.SparqlException
+
+class CompilerException(
     message: String,
     val type: Type,
     val stacktrace: String
-): RuntimeException("$type: $message\n$stacktrace") {
+): SparqlException("$type: $message\n$stacktrace") {
 
     enum class Type {
         SyntaxError,

--- a/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/analyser/Analyser.kt
+++ b/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/analyser/Analyser.kt
@@ -2,7 +2,7 @@
 
 package dev.tesserakt.sparql.compiler.analyser
 
-import dev.tesserakt.sparql.compiler.CompilerError
+import dev.tesserakt.sparql.compiler.CompilerException
 import dev.tesserakt.sparql.compiler.lexer.Lexer
 import dev.tesserakt.sparql.compiler.lexer.Token
 import dev.tesserakt.sparql.types.QueryAtom
@@ -155,10 +155,10 @@ abstract class Analyser<RT: QueryAtom?> {
     }
 
     protected fun bail(message: String = "Internal compiler error"): Nothing {
-        throw CompilerError(
+        throw CompilerException(
             message = "Failed during the execution of `${this::class.simpleName!!}`",
-            type = CompilerError.Type.StructuralError,
-            stacktrace = lexer.stacktrace(message = message, type = CompilerError.Type.StructuralError)
+            type = CompilerException.Type.StructuralError,
+            stacktrace = lexer.stacktrace(message = message, type = CompilerException.Type.StructuralError)
         )
     }
 

--- a/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/lexer/Lexer.kt
+++ b/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/lexer/Lexer.kt
@@ -1,6 +1,6 @@
 package dev.tesserakt.sparql.compiler.lexer
 
-import dev.tesserakt.sparql.compiler.CompilerError
+import dev.tesserakt.sparql.compiler.CompilerException
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -57,15 +57,15 @@ abstract class Lexer {
      * Returns a visual overview for the current line being processed and a line indicating the currently observed
      *  range
      */
-    abstract fun stacktrace(type: CompilerError.Type, message: String): String
+    abstract fun stacktrace(type: CompilerException.Type, message: String): String
 
     abstract fun position(): Int
 
     protected fun bail(message: String = "Internal compiler error"): Nothing {
-        throw CompilerError(
+        throw CompilerException(
             message = "Syntax error at index ${position()}",
-            type = CompilerError.Type.SyntaxError,
-            stacktrace = stacktrace(CompilerError.Type.SyntaxError, message)
+            type = CompilerException.Type.SyntaxError,
+            stacktrace = stacktrace(CompilerException.Type.SyntaxError, message)
         )
     }
 

--- a/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/lexer/StringLexer.kt
+++ b/sparql/compiler/src/commonMain/kotlin/dev/tesserakt/sparql/compiler/lexer/StringLexer.kt
@@ -1,6 +1,6 @@
 package dev.tesserakt.sparql.compiler.lexer
 
-import dev.tesserakt.sparql.compiler.CompilerError
+import dev.tesserakt.sparql.compiler.CompilerException
 
 @Suppress("NOTHING_TO_INLINE")
 class StringLexer(private val input: String): Lexer() {
@@ -24,10 +24,10 @@ class StringLexer(private val input: String): Lexer() {
 
     override fun position() = start
 
-    override fun stacktrace(type: CompilerError.Type, message: String): String {
+    override fun stacktrace(type: CompilerException.Type, message: String): String {
         return when (type) {
-            CompilerError.Type.SyntaxError -> syntaxErrorStacktrace(message = message)
-            CompilerError.Type.StructuralError -> analyserStacktrace(message = message)
+            CompilerException.Type.SyntaxError -> syntaxErrorStacktrace(message = message)
+            CompilerException.Type.StructuralError -> analyserStacktrace(message = message)
         }
     }
 

--- a/sparql/test/src/test/kotlin/CompilerTest.kt
+++ b/sparql/test/src/test/kotlin/CompilerTest.kt
@@ -1,7 +1,7 @@
 
 import TestEnvironment.Companion.test
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.compiler.CompilerError
+import dev.tesserakt.sparql.compiler.CompilerException
 import dev.tesserakt.sparql.types.Expression
 import dev.tesserakt.sparql.types.SelectQueryStructure
 import dev.tesserakt.sparql.types.TriplePattern
@@ -34,7 +34,7 @@ class CompilerTest {
         "SELECT * WHERE { ?s a/<predicate2>*/<predicate3>?o. }" satisfies {
             body.patterns.first().p is TriplePattern.UnboundSequence
         }
-        "SELECT * WHERE { ?s a/?p1*/?p2?o. }" causes CompilerError.Type.StructuralError
+        "SELECT * WHERE { ?s a/?p1*/?p2?o. }" causes CompilerException.Type.StructuralError
         "SELECT * WHERE { ?s (<predicate2>|<predicate3>)?o. }" satisfies {
             body.patterns.first().p is TriplePattern.SimpleAlts
         }
@@ -224,16 +224,16 @@ class CompilerTest {
                     }
                 }
             }
-        """ causes CompilerError.Type.SyntaxError
+        """ causes CompilerException.Type.SyntaxError
         /* expected failure cases */
-        "SELECT TEST WHERE { ?s a TEST . }" causes CompilerError.Type.SyntaxError
-        "SELECT * WHERE { ?s () TEST . }" causes CompilerError.Type.StructuralError
-        "SELECT * WHERE { ?s a ?test " causes CompilerError.Type.StructuralError
-        "SELECT * WHERE { ?s <predicate2>/(<predicate3> ?o2.}" causes CompilerError.Type.StructuralError
-        "SELECT * WHERE { ?s a ?type , }" causes CompilerError.Type.StructuralError
-        "PREFIX ex: <http://example.org> SELECT * WHERE { ?s ex:prop/other ?o }" causes CompilerError.Type.SyntaxError
-        "prefix ex: <http://example.org> select*{?s dc:title ?o}" causes CompilerError.Type.StructuralError
-        "select(count(distinct ?s as ?count){?s?p?o}" causes CompilerError.Type.StructuralError
+        "SELECT TEST WHERE { ?s a TEST . }" causes CompilerException.Type.SyntaxError
+        "SELECT * WHERE { ?s () TEST . }" causes CompilerException.Type.StructuralError
+        "SELECT * WHERE { ?s a ?test " causes CompilerException.Type.StructuralError
+        "SELECT * WHERE { ?s <predicate2>/(<predicate3> ?o2.}" causes CompilerException.Type.StructuralError
+        "SELECT * WHERE { ?s a ?type , }" causes CompilerException.Type.StructuralError
+        "PREFIX ex: <http://example.org> SELECT * WHERE { ?s ex:prop/other ?o }" causes CompilerException.Type.SyntaxError
+        "prefix ex: <http://example.org> select*{?s dc:title ?o}" causes CompilerException.Type.StructuralError
+        "select(count(distinct ?s as ?count){?s?p?o}" causes CompilerException.Type.StructuralError
     }
 
     @Test

--- a/sparql/test/src/test/kotlin/TestEnvironment.kt
+++ b/sparql/test/src/test/kotlin/TestEnvironment.kt
@@ -1,6 +1,6 @@
 
 import dev.tesserakt.sparql.Compiler
-import dev.tesserakt.sparql.compiler.CompilerError
+import dev.tesserakt.sparql.compiler.CompilerException
 import dev.tesserakt.sparql.debug.ASTWriter
 import dev.tesserakt.sparql.types.QueryStructure
 import dev.tesserakt.util.printerrln
@@ -45,7 +45,7 @@ class TestEnvironment private constructor() {
                 .replace(Regex("#.*+\\n?"), "")
                 .replace(Regex("\\s+"), " ")
                 .trim()
-            if (t is CompilerError) {
+            if (t is CompilerException) {
                 printerrln("Query ${i + 1} failed due to a compiler error: `${compact}`\n${t.message}")
             } else {
                 printerrln("Query ${i + 1} failed due to an unexpected error: `${compact}`\n${t.message}")
@@ -75,14 +75,14 @@ class TestEnvironment private constructor() {
 
     data class CompilationFailureTest(
         override val input: String,
-        val type: CompilerError.Type
+        val type: CompilerException.Type
     ): Test() {
 
         override operator fun invoke() {
             try {
                 Compiler().compile(input)
                 throw AssertionError("Compilation succeeded unexpectedly!")
-            } catch (c: CompilerError) {
+            } catch (c: CompilerException) {
                 // exactly what is expected, so not throwing anything
                 assertEquals(c.type, type, "Compilation failed for a different reason!")
             }
@@ -95,7 +95,7 @@ class TestEnvironment private constructor() {
         addTest(ASTTest(input = this, test = validation))
     }
 
-    infix fun String.causes(error: CompilerError.Type) {
+    infix fun String.causes(error: CompilerException.Type) {
         addTest(CompilationFailureTest(input = this, type = error))
     }
 


### PR DESCRIPTION
Adds a base exception type for all SPARQL exceptions to extend, available in the API for all SPARQL dependants

Resolves #46 