### PR TITLE
Transitive dependency fix

### DIFF
--- a/serialization/common/build.gradle.kts
+++ b/serialization/common/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":rdf"))
+                api(project(":rdf"))
             }
         }
     }

--- a/stream/ldes/build.gradle.kts
+++ b/stream/ldes/build.gradle.kts
@@ -6,7 +6,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":rdf"))
+                api(project(":rdf"))
                 api("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
             }
         }


### PR DESCRIPTION
Fixed two modules incorrectly referring to the RDF module as an implementation dependency instead of an API one