### PR TITLE
Bitset-based mapping implementation

### DIFF
--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MappingArray.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MappingArray.kt
@@ -1,6 +1,6 @@
 package dev.tesserakt.sparql.runtime.collection
 
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.runtime.stream.OptimisedStream
 import dev.tesserakt.sparql.util.Cardinality
 

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/MultiHashMappingArray.kt
@@ -1,6 +1,10 @@
 package dev.tesserakt.sparql.runtime.collection
 
-import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifier
+import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifierSet
+import dev.tesserakt.sparql.runtime.evaluation.TermIdentifier
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.runtime.stream.OptimisedStream
 import dev.tesserakt.sparql.runtime.stream.emptyIterable
 import dev.tesserakt.sparql.util.Cardinality

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/SimpleMappingArray.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/SimpleMappingArray.kt
@@ -1,6 +1,6 @@
 package dev.tesserakt.sparql.runtime.collection
 
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.runtime.stream.CollectedStream
 import dev.tesserakt.sparql.util.Cardinality
 import dev.tesserakt.util.removeLastElement

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/Util.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/collection/Util.kt
@@ -1,6 +1,6 @@
 package dev.tesserakt.sparql.runtime.collection
 
-import dev.tesserakt.sparql.runtime.evaluation.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 
 fun MappingArray(context: QueryContext, bindings: Collection<String>) = when {
     bindings.isNotEmpty() -> MultiHashMappingArray(context, bindings = bindings.toSet())

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifier.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifier.kt
@@ -1,5 +1,6 @@
 package dev.tesserakt.sparql.runtime.evaluation
 
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import kotlin.jvm.JvmInline
 
 @JvmInline

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifierSet.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingIdentifierSet.kt
@@ -1,5 +1,6 @@
 package dev.tesserakt.sparql.runtime.evaluation
 
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import kotlin.jvm.JvmInline
 
 // not a value class as we have a custom equals check based on the contents of the `IntArray`, instead of reference equality

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/BindingsImpl.kt
@@ -2,6 +2,8 @@ package dev.tesserakt.sparql.runtime.evaluation
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.Bindings
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 
 class BindingsImpl(private val context: QueryContext, private val mapping: Mapping): Bindings {
 
@@ -19,7 +21,14 @@ class BindingsImpl(private val context: QueryContext, private val mapping: Mappi
         if (other !is BindingsImpl) {
             return false
         }
-        return mapping == other.mapping
+        val a = mapping.asIterable().iterator()
+        val b = other.mapping.asIterable().iterator()
+        while (a.hasNext() && b.hasNext()) {
+            if (a.next() != b.next()) {
+                return false
+            }
+        }
+        return !a.hasNext() && !b.hasNext()
     }
 
     override fun toString() = iterable.joinToString(prefix = "{", postfix = "}") { "${it.first} = ${it.second}" }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Delta.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Delta.kt
@@ -1,6 +1,7 @@
 package dev.tesserakt.sparql.runtime.evaluation
 
 import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import kotlin.jvm.JvmInline
 
 sealed interface Delta
@@ -27,8 +28,7 @@ value class DataAddition(override val value: Quad): AdditionDelta,
 data class MappingAddition(
     override val value: Mapping,
     override val origin: DataDelta?
-): AdditionDelta,
-    MappingDelta {
+): AdditionDelta, MappingDelta {
     override fun toString() = if (origin != null) "[+] $value ($origin)" else "[+] $value"
 }
 
@@ -41,7 +41,6 @@ value class DataDeletion(override val value: Quad): DeletionDelta,
 data class MappingDeletion(
     override val value: Mapping,
     override val origin: DataDelta?
-): DeletionDelta,
-    MappingDelta {
+): DeletionDelta, MappingDelta {
     override fun toString() = if (origin != null) "[-] $value ($origin)" else "[-] $value"
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/TermIdentifier.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/TermIdentifier.kt
@@ -1,6 +1,7 @@
 package dev.tesserakt.sparql.runtime.evaluation
 
 import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import kotlin.jvm.JvmInline
 
 @JvmInline

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Util.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/Util.kt
@@ -1,5 +1,6 @@
 package dev.tesserakt.sparql.runtime.evaluation
 
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.runtime.stream.Stream
 import dev.tesserakt.sparql.runtime.stream.mapped
 

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/BitsetQueryContext.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/BitsetQueryContext.kt
@@ -1,0 +1,53 @@
+package dev.tesserakt.sparql.runtime.evaluation.context
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.mapping.BitsetMapping
+import dev.tesserakt.sparql.types.QueryStructure
+import dev.tesserakt.sparql.types.extractAllBindings
+
+class BitsetQueryContext(ast: QueryStructure): QueryContext {
+
+    // note: this cannot be a read only list, as some add bindings during initialisation, such as repeating paths
+    private val bindings = ast.body.extractAllBindings().mapTo(mutableListOf()) { it.name }
+    private val bindingsLut = bindings.withIndex().associateTo(mutableMapOf()) { (i, value) -> value to i }
+
+    private val terms = mutableMapOf<Quad.Term, Int>()
+    // as terms are never removed from an active context, we can keep it as a regular list without risking IDs
+    // shifting over
+    private val termsLut = mutableListOf<Quad.Term>()
+
+    override fun resolveBinding(value: String): Int {
+        return bindingsLut.getOrPut(value) {
+            val i = bindings.size
+            require(i < 32)
+            require(bindingsLut.size == i)
+            bindings.add(value)
+            i
+        }
+    }
+
+    override fun resolveTerm(value: Quad.Term): Int {
+        return terms.getOrPut(value) {
+            val i = terms.size
+            termsLut.add(value)
+            i
+        }
+    }
+
+    override fun resolveBinding(id: Int): String {
+        return bindings[id]
+    }
+
+    override fun resolveTerm(id: Int): Quad.Term {
+        return termsLut[id]
+    }
+
+    override fun create(terms: Iterable<Pair<String, Quad.Term>>): BitsetMapping {
+        return BitsetMapping(this, terms)
+    }
+
+    override fun emptyMapping(): BitsetMapping {
+        return BitsetMapping.EMPTY
+    }
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/Factory.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/Factory.kt
@@ -1,0 +1,11 @@
+package dev.tesserakt.sparql.runtime.evaluation.context
+
+import dev.tesserakt.sparql.types.QueryStructure
+import dev.tesserakt.sparql.types.extractAllBindings
+
+fun QueryContext(ast: QueryStructure): QueryContext {
+    return when {
+        ast.body.extractAllBindings().distinct().size < 32 -> BitsetQueryContext(ast)
+        else -> IntPairQueryContext(ast)
+    }
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/GlobalQueryContext.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/GlobalQueryContext.kt
@@ -1,14 +1,12 @@
-package dev.tesserakt.sparql.runtime.evaluation
+package dev.tesserakt.sparql.runtime.evaluation.context
 
 import dev.tesserakt.rdf.types.Quad
-import dev.tesserakt.sparql.types.QueryStructure
-import dev.tesserakt.sparql.types.extractAllBindings
+import dev.tesserakt.sparql.runtime.evaluation.mapping.IntPairMapping
 
-class QueryContextImpl(ast: QueryStructure): QueryContext {
+object GlobalQueryContext: QueryContext {
 
-    // note: this cannot be a read only list, as some add bindings during initialisation, such as repeating paths
-    private val bindings = ast.body.extractAllBindings().mapTo(mutableListOf()) { it.name }
-    private val bindingsLut = bindings.withIndex().associateTo(mutableMapOf()) { (i, value) -> value to i }
+    private val bindings = mutableListOf<String>()
+    private val bindingsLut = mutableMapOf<String, Int>()
 
     private val terms = mutableMapOf<Quad.Term, Int>()
     // as terms are never removed from an active context, we can keep it as a regular list without risking IDs
@@ -39,5 +37,10 @@ class QueryContextImpl(ast: QueryStructure): QueryContext {
     override fun resolveTerm(id: Int): Quad.Term {
         return termsLut[id]
     }
+
+    override fun create(terms: Iterable<Pair<String, Quad.Term>>): IntPairMapping =
+        IntPairMapping(this, terms)
+
+    override fun emptyMapping(): IntPairMapping = IntPairMapping.EMPTY
 
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/QueryContext.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/context/QueryContext.kt
@@ -1,6 +1,7 @@
-package dev.tesserakt.sparql.runtime.evaluation
+package dev.tesserakt.sparql.runtime.evaluation.context
 
 import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 
 interface QueryContext {
 
@@ -11,5 +12,9 @@ interface QueryContext {
     fun resolveBinding(id: Int): String
 
     fun resolveTerm(id: Int): Quad.Term
+
+    fun create(terms: Iterable<Pair<String, Quad.Term>>): Mapping
+
+    fun emptyMapping(): Mapping
 
 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/mapping/BitsetMapping.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/mapping/BitsetMapping.kt
@@ -6,6 +6,7 @@ import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifierSet
 import dev.tesserakt.sparql.runtime.evaluation.TermIdentifier
 import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.util.bitIterator
+import dev.tesserakt.util.cloneTo
 
 class BitsetMapping private constructor(
     // self-managed bitmask
@@ -82,10 +83,13 @@ class BitsetMapping private constructor(
                         a.next()
                     } else {
                         // all other elements to the right can get added right away
-                        terms[i++] = other.get(right)
-                        b.forEach {
-                            terms[i++] = other.get(it)
-                        }
+                        val remaining = b.remaining() + 1
+                        other.terms.cloneTo(
+                            target = terms,
+                            thisOffset = other.terms.size - remaining,
+                            targetOffset = i,
+                            length = remaining
+                        )
                         break
                     }
                 }
@@ -95,10 +99,13 @@ class BitsetMapping private constructor(
                         b.next()
                     } else {
                         // all other elements to the right can get added right away
-                        terms[i++] = this.get(left)
-                        a.forEach {
-                            terms[i++] = this.get(it)
-                        }
+                        val remaining = a.remaining() + 1
+                        this.terms.cloneTo(
+                            target = terms,
+                            thisOffset = this.terms.size - remaining,
+                            targetOffset = i,
+                            length = remaining
+                        )
                         break
                     }
                 }
@@ -110,20 +117,26 @@ class BitsetMapping private constructor(
                     } else {
                         // all other elements to the right can get added right away
                         // this first step, `terms[i++] = other.get(right)`, is not required, as here, left == right
-                        b.forEach {
-                            terms[i++] = other.get(it)
-                        }
+                        val remaining = b.remaining()
+                        other.terms.cloneTo(
+                            target = terms,
+                            thisOffset = other.terms.size - remaining,
+                            targetOffset = i,
+                            length = remaining
+                        )
                         break
                     }
                     right = if (b.hasNext()) {
                         b.next()
                     } else {
                         // all other elements to the right can get added right away
-                        terms[i++] = this.get(left)
-                        // FIXME use `remaining()` instead to avoid unnecessary `get()` calls
-                        a.forEach {
-                            terms[i++] = this.get(it)
-                        }
+                        val remaining = a.remaining() + 1
+                        this.terms.cloneTo(
+                            target = terms,
+                            thisOffset = this.terms.size - remaining,
+                            targetOffset = i,
+                            length = remaining
+                        )
                         break
                     }
                 }

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/mapping/Factory.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/mapping/Factory.kt
@@ -1,0 +1,14 @@
+package dev.tesserakt.sparql.runtime.evaluation.mapping
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import kotlin.jvm.JvmName
+
+
+fun mappingOf(context: QueryContext, vararg pairs: Pair<String, Quad.Term>) =
+    context.create(pairs.asIterable())
+
+@JvmName("mappingOfNullable")
+fun mappingOf(context: QueryContext, vararg pairs: Pair<String?, Quad.Term>) =
+    @Suppress("UNCHECKED_CAST")
+    context.create(pairs.filter { it.first != null } as List<Pair<String, Quad.Term>>)

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/mapping/Mapping.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/evaluation/mapping/Mapping.kt
@@ -1,0 +1,31 @@
+package dev.tesserakt.sparql.runtime.evaluation.mapping
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifier
+import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifierSet
+import dev.tesserakt.sparql.runtime.evaluation.TermIdentifier
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+
+interface Mapping {
+
+    fun join(other: Mapping): Mapping?
+
+    fun keys(context: QueryContext): Iterable<String>
+
+    fun asIterable(context: QueryContext): Iterable<Pair<String, Quad.Term>>
+
+    fun asIterable(): Iterable<Pair<BindingIdentifier, TermIdentifier>>
+
+    fun toMap(context: QueryContext): Map<String, Quad.Term>
+
+    fun get(context: QueryContext, binding: String): Quad.Term?
+
+    fun get(binding: BindingIdentifier): TermIdentifier?
+
+    fun retain(bindings: BindingIdentifierSet): Mapping
+
+    fun compatibleWith(other: Mapping): Boolean
+
+    fun isEmpty(): Boolean
+
+}

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/BasicGraphPatternState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/BasicGraphPatternState.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.DataDelta
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
-import dev.tesserakt.sparql.runtime.evaluation.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.stream.Stream
 import dev.tesserakt.sparql.runtime.stream.collect
 import dev.tesserakt.sparql.types.GraphPattern

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExclusionFilterState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExclusionFilterState.kt
@@ -1,6 +1,8 @@
 package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.Filter
 import dev.tesserakt.sparql.util.Counter
@@ -143,12 +145,12 @@ sealed interface ExclusionFilterState: MutableFilterState {
             // if the count becomes > 0 through this delta, all mappings should be removed;
             if (count == 0 && change != 0) {
                 check(change > 0) { "Invalid internal state!" }
-                return streamOf(MappingDeletion(emptyMapping(), null))
+                return streamOf(MappingDeletion(state.context.emptyMapping(), null))
             }
             // similarly, if the count becomes 0 through this delta, all mappings should be restored
             if (count > 0 && count + change <= 0) {
                 check(count + change == 0) { "Invalid internal state!" }
-                return streamOf(MappingAddition(emptyMapping(), null))
+                return streamOf(MappingAddition(state.context.emptyMapping(), null))
             }
             // nothing changed, so the peek is empty
             return emptyStream()

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExpressionFilter.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/ExpressionFilter.kt
@@ -1,7 +1,7 @@
 package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
-import dev.tesserakt.sparql.runtime.evaluation.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.stream.Stream
 import dev.tesserakt.sparql.runtime.stream.filtered
 import dev.tesserakt.sparql.types.Expression

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/FilterExpression.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/FilterExpression.kt
@@ -4,10 +4,10 @@ import dev.tesserakt.rdf.ontology.XSD
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifier
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
-import dev.tesserakt.sparql.runtime.evaluation.QueryContext
 import dev.tesserakt.sparql.runtime.evaluation.TermIdentifier
 import dev.tesserakt.sparql.runtime.evaluation.TermIdentifier.Companion.get
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.types.Expression
 import dev.tesserakt.sparql.types.Expression.*
 import kotlin.jvm.JvmInline

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GraphPatternFilterState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GraphPatternFilterState.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.DataDelta
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
-import dev.tesserakt.sparql.runtime.evaluation.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.Filter
 import dev.tesserakt.sparql.util.Bitmask

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GroupPatternState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/GroupPatternState.kt
@@ -1,6 +1,10 @@
 package dev.tesserakt.sparql.runtime.query
 
-import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.DataDelta
+import dev.tesserakt.sparql.runtime.evaluation.MappingAddition
+import dev.tesserakt.sparql.runtime.evaluation.MappingDeletion
+import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.TriplePatternSet
 import dev.tesserakt.sparql.types.Union

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/InclusionFilterState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/InclusionFilterState.kt
@@ -1,6 +1,8 @@
 package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.Filter
 import dev.tesserakt.sparql.util.Counter
@@ -143,12 +145,12 @@ sealed interface InclusionFilterState: MutableFilterState {
             // if the count becomes > 0 through this delta, all mappings should be added;
             if (count == 0 && change != 0) {
                 check(change > 0) { "Invalid internal state!" }
-                return streamOf(MappingAddition(emptyMapping(), null))
+                return streamOf(MappingAddition(state.context.emptyMapping(), null))
             }
             // similarly, if the count becomes 0 through this delta, all mappings should be removed
             if (count > 0 && count + change <= 0) {
                 check(count + change == 0) { "Invalid internal state!" }
-                return streamOf(MappingDeletion(emptyMapping(), null))
+                return streamOf(MappingDeletion(state.context.emptyMapping(), null))
             }
             // nothing changed, so the peek is empty
             return emptyStream()

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/JoinTree.kt
@@ -2,6 +2,7 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.collection.MappingArray
 import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.TriplePattern
 import dev.tesserakt.sparql.types.Union

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
@@ -2,7 +2,6 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.compat.Compat
 import dev.tesserakt.sparql.runtime.evaluation.*
-import dev.tesserakt.sparql.runtime.evaluation.context.IntPairQueryContext
 import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.query.QueryState.ResultChange.Companion.into
 import dev.tesserakt.sparql.types.QueryStructure
@@ -14,7 +13,7 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
 
     inner class Processor {
 
-        val context = IntPairQueryContext(ast)
+        val context = QueryContext(ast)
         private val state = BasicGraphPatternState(context, ast = Compat.apply(ast.body))
 
         /**

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/QueryState.kt
@@ -2,6 +2,8 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.compat.Compat
 import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.context.IntPairQueryContext
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.query.QueryState.ResultChange.Companion.into
 import dev.tesserakt.sparql.types.QueryStructure
 import kotlin.jvm.JvmInline
@@ -12,7 +14,7 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
 
     inner class Processor {
 
-        val context = QueryContextImpl(ast)
+        val context = IntPairQueryContext(ast)
         private val state = BasicGraphPatternState(context, ast = Compat.apply(ast.body))
 
         /**
@@ -24,7 +26,7 @@ sealed class QueryState<ResultType, Q: QueryStructure>(
                 // getting all current results by joining with an empty new mapping
                 .join(
                     MappingAddition(
-                        value = emptyMapping(),
+                        value = state.context.emptyMapping(),
                         origin = null
                     )
                 )

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/RepeatingPathState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/RepeatingPathState.kt
@@ -3,7 +3,12 @@ package dev.tesserakt.sparql.runtime.query
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.newAnonymousBinding
 import dev.tesserakt.sparql.runtime.collection.MappingArray
-import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.DataAddition
+import dev.tesserakt.sparql.runtime.evaluation.DataDeletion
+import dev.tesserakt.sparql.runtime.evaluation.DataDelta
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.mapping.mappingOf
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.TriplePattern
 import dev.tesserakt.sparql.types.matches
@@ -610,7 +615,7 @@ sealed class RepeatingPathState {
                 val new = segments.newPathsOnAdding(segment)
                 // checking if any valid path has been reached
                 if (new.any { it.start == start.term && it.end == end.term }) {
-                    return streamOf(emptyMapping())
+                    return streamOf(context.emptyMapping())
                 }
             }
             return emptyStream()
@@ -632,7 +637,7 @@ sealed class RepeatingPathState {
                 val remaining = segments.remainingPathsOnRemoving(segment)
                 // checking if any valid path remains
                 if (remaining.none { it.start == start.term && it.end == end.term }) {
-                    return streamOf(emptyMapping())
+                    return streamOf(context.emptyMapping())
                 }
             }
             return emptyStream()
@@ -728,7 +733,7 @@ sealed class RepeatingPathState {
                     )
                 }
             if (segments.newPathsOnAdding(added).any { it.start == start.term && it.end == end.term }) {
-                return streamOf(emptyMapping())
+                return streamOf(context.emptyMapping())
             }
             return emptyStream()
         }
@@ -754,7 +759,7 @@ sealed class RepeatingPathState {
                     .remainingPathsOnRemoving(removed)
                     .none { it.start == start.term && it.end == end.term }
             ) {
-                return streamOf(emptyMapping())
+                return streamOf(context.emptyMapping())
             }
             return emptyStream()
         }
@@ -1197,7 +1202,7 @@ sealed class RepeatingPathState {
         override fun peek(addition: DataAddition): Stream<Mapping> {
             val quad = addition.value
             return if (!satisfied && inner.matches(quad.p)) {
-                streamOf(emptyMapping())
+                streamOf(context.emptyMapping())
             } else {
                 emptyStream()
             }
@@ -1275,7 +1280,7 @@ sealed class RepeatingPathState {
                         )
                     }
                 if (segments.newPathsOnAdding(new).any { it.start == start.term && it.end == end.term }) {
-                    return streamOf(emptyMapping())
+                    return streamOf(context.emptyMapping())
                 }
             }
             return emptyStream()

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/TriplePatternState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/TriplePatternState.kt
@@ -4,6 +4,9 @@ import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.RuntimeStatistics
 import dev.tesserakt.sparql.runtime.collection.MappingArray
 import dev.tesserakt.sparql.runtime.evaluation.*
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.mapping.mappingOf
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.TriplePattern
 import dev.tesserakt.sparql.types.matches
@@ -304,7 +307,7 @@ sealed class TriplePatternState<P : TriplePattern.Predicate>(
     protected fun subjectMappingOrNull(quad: Quad): Mapping? {
         return when (s) {
             is TriplePattern.Binding -> mappingOf(context, s.name to quad.s)
-            is TriplePattern.Exact -> if (s.term == quad.s) EmptyMapping else null
+            is TriplePattern.Exact -> if (s.term == quad.s) context.emptyMapping() else null
         }
     }
 
@@ -320,7 +323,7 @@ sealed class TriplePatternState<P : TriplePattern.Predicate>(
     protected fun objectMappingOrNull(quad: Quad): Mapping? {
         return when (o) {
             is TriplePattern.Binding -> mappingOf(context, o.name to quad.o)
-            is TriplePattern.Exact -> if (o.term == quad.o) EmptyMapping else null
+            is TriplePattern.Exact -> if (o.term == quad.o) context.emptyMapping() else null
         }
     }
 

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/UnionState.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/query/UnionState.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.runtime.query
 
 import dev.tesserakt.sparql.runtime.evaluation.DataDelta
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
-import dev.tesserakt.sparql.runtime.evaluation.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.types.GraphPatternSegment
 import dev.tesserakt.sparql.types.SelectQuerySegment

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Extensions.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/Extensions.kt
@@ -1,8 +1,8 @@
 package dev.tesserakt.sparql.runtime.stream
 
 import dev.tesserakt.sparql.runtime.collection.MappingArray
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
 import dev.tesserakt.sparql.runtime.evaluation.MappingDelta
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.runtime.query.MutableJoinState
 import dev.tesserakt.sparql.util.Cardinality
 import dev.tesserakt.sparql.util.ZeroCardinality

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMultiJoin.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamMultiJoin.kt
@@ -1,7 +1,6 @@
 package dev.tesserakt.sparql.runtime.stream
 
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
-import dev.tesserakt.sparql.runtime.evaluation.emptyMapping
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.util.Cardinality
 
 class StreamMultiJoin(
@@ -20,7 +19,7 @@ class StreamMultiJoin(
 
         private var left = source1.next()
         // the empty mapping is never read from, so this is not an error (instant `increment()` call)
-        private var right: Mapping = emptyMapping()
+        private lateinit var right: Mapping
 
         private var next: Mapping? = null
 

--- a/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamSingleJoin.kt
+++ b/sparql/runtime/src/commonMain/kotlin/dev/tesserakt/sparql/runtime/stream/StreamSingleJoin.kt
@@ -1,7 +1,6 @@
 package dev.tesserakt.sparql.runtime.stream
 
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
-import dev.tesserakt.sparql.runtime.evaluation.emptyMapping
+import dev.tesserakt.sparql.runtime.evaluation.mapping.Mapping
 import dev.tesserakt.sparql.util.Cardinality
 
 class StreamSingleJoin(
@@ -16,7 +15,7 @@ class StreamSingleJoin(
     ): Iterator<Mapping> {
 
         // the empty mapping is never read from, so this is not an error (instant `increment()` call)
-        private var right: Mapping = emptyMapping()
+        private lateinit var right: Mapping
 
         private var next: Mapping? = null
 

--- a/sparql/test/src/test/kotlin/MappingTest.kt
+++ b/sparql/test/src/test/kotlin/MappingTest.kt
@@ -3,8 +3,7 @@ import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
 import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifierSet
-import dev.tesserakt.sparql.runtime.evaluation.GlobalQueryContext
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.context.GlobalQueryContext
 import org.junit.Test
 import kotlin.random.Random
 import kotlin.test.assertContentEquals
@@ -44,14 +43,14 @@ class MappingTest {
     @Test
     fun mappingConversion1() {
         val data = List(100) { createMapping(it) }
-        val converted = data.map { Mapping(GlobalQueryContext, it) }
+        val converted = data.map { GlobalQueryContext.create(it.map { it.toPair() }) }
         assertContentEquals(data, converted.map { it.toMap(GlobalQueryContext) })
     }
 
     @Test
     fun mappingConversion2() {
         val data = List(100) { createMapping(it) }
-        val converted = data.map { Mapping(GlobalQueryContext, it) }
+        val converted = data.map { GlobalQueryContext.create(it.map { it.toPair() }) }
         repeat(data.size) { index ->
             val map = data[index]
             map.forEach { (key, value) ->
@@ -63,7 +62,7 @@ class MappingTest {
     @Test
     fun mappingConversion3() {
         val data = List(100) { createMapping(it) }
-        val converted = data.map { Mapping(GlobalQueryContext, it) }
+        val converted = data.map { GlobalQueryContext.create(it.map { it.toPair() }) }
         repeat(data.size) { index ->
             assertContentEquals(
                 expected = data[index].map { it.toPair() }.sortedBy { it.first },
@@ -74,7 +73,7 @@ class MappingTest {
     @Test
     fun mappingConversion4() {
         val data = List(100) { createMapping(it) }
-        val converted = data.map { Mapping(GlobalQueryContext, it) }
+        val converted = data.map { GlobalQueryContext.create(it.map { it.toPair() }) }
         val rng = Random(1)
         val subset = data.map { it.toMutableMap().apply { keys.retainAll { rng.nextBoolean() } } }
         repeat(data.size) { index ->
@@ -97,8 +96,8 @@ class MappingTest {
                 right.add(new)
             }
         }
-        val l = left.map { Mapping(GlobalQueryContext, it) }
-        val r = right.map { Mapping(GlobalQueryContext, it) }
+        val l = left.map { GlobalQueryContext.create(it.map { it.toPair() }) }
+        val r = right.map { GlobalQueryContext.create(it.map { it.toPair() }) }
         val original = left.flatMap { l -> right.mapNotNull { r -> join(l, r) } }
         val new = l.flatMap { l -> r.mapNotNull { r -> l.join(r) } }
             .map { it.toMap(GlobalQueryContext) }

--- a/sparql/test/src/test/kotlin/StreamTest.kt
+++ b/sparql/test/src/test/kotlin/StreamTest.kt
@@ -1,7 +1,7 @@
 
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
-import dev.tesserakt.sparql.runtime.evaluation.GlobalQueryContext
-import dev.tesserakt.sparql.runtime.evaluation.mappingOf
+import dev.tesserakt.sparql.runtime.evaluation.context.GlobalQueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.mappingOf
 import dev.tesserakt.sparql.runtime.stream.*
 import dev.tesserakt.sparql.util.Counter
 import kotlin.test.Test

--- a/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/LowBindingCountMapping.kt
+++ b/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/LowBindingCountMapping.kt
@@ -1,0 +1,183 @@
+package dev.tesserakt
+
+import dev.tesserakt.rdf.types.Quad
+import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifier
+import dev.tesserakt.sparql.runtime.evaluation.QueryContext
+import dev.tesserakt.sparql.runtime.evaluation.TermIdentifier
+
+class LowBindingCountMapping private constructor(
+    // self-managed bitmask
+    private val bindings: Int,
+    // all term values associated with the various bindings above
+    private val terms: IntArray,
+) {
+
+    constructor(context: QueryContext, source: Map<String, Quad.Term>): this(
+        bindings = source.asIterable().fold(initial = 0) { acc, entry -> acc or (1 shl context.resolveBinding(entry.key)) },
+        terms = source.asIterable().sortedBy { context.resolveBinding(it.key) }.map { context.resolveTerm(it.value) }.toIntArray(),
+    )
+
+    constructor(context: QueryContext, source: Iterable<Pair<String, Quad.Term>>): this(
+        bindings = source.asIterable().fold(initial = 0) { acc, entry -> acc or context.resolveBinding(entry.first) },
+        terms = source.asIterable().sortedBy { context.resolveBinding(it.first) }.map { context.resolveTerm(it.second) }.toIntArray(),
+    )
+
+    private val hashCode = bindings + terms.contentHashCode()
+
+    fun get(binding: BindingIdentifier): TermIdentifier? {
+        // getting the binding index associated with `binding`
+        val index = bindingIndex(target = binding.id)
+        if (index == -1) {
+            return null
+        }
+        return TermIdentifier(terms[index])
+    }
+
+    fun join(other: LowBindingCountMapping): LowBindingCountMapping? {
+        if (this.bindings == 0) {
+            return other
+        }
+        if (other.bindings == 0) {
+            return this
+        }
+        val c = count(other)
+        if (c == -1) {
+            // incompatible mappings
+            return null
+        }
+        val terms = IntArray(c)
+        var i = 0
+        val a = this.bindings.bitIterator()
+        val b = other.bindings.bitIterator()
+        var left = a.next()
+        var right = b.next()
+        while (true) {
+            when {
+                left < right -> {
+                    terms[i++] = this.get(left)
+                    left = if (a.hasNext()) {
+                        a.next()
+                    } else {
+                        // all other elements to the right can get added right away
+                        terms[i++] = other.get(right)
+                        b.forEach {
+                            terms[i++] = other.get(it)
+                        }
+                        break
+                    }
+                }
+                right < left -> {
+                    terms[i++] = other.get(right)
+                    right = if (b.hasNext()) {
+                        b.next()
+                    } else {
+                        // all other elements to the right can get added right away
+                        terms[i++] = this.get(left)
+                        a.forEach {
+                            terms[i++] = this.get(it)
+                        }
+                        break
+                    }
+                }
+                else /* right == left */ -> {
+                    // no equality check required; `count` took care of that
+                    terms[i++] = this.get(left)
+                    left = if (a.hasNext()) {
+                        a.next()
+                    } else {
+                        // all other elements to the right can get added right away
+                        // this first step, `terms[i++] = other.get(right)`, is not required, as here, left == right
+                        b.forEach {
+                            terms[i++] = other.get(it)
+                        }
+                        break
+                    }
+                    right = if (b.hasNext()) {
+                        b.next()
+                    } else {
+                        // all other elements to the right can get added right away
+                        terms[i++] = this.get(left)
+                        // FIXME use `remaining()` instead to avoid unnecessary `get()` calls
+                        a.forEach {
+                            terms[i++] = this.get(it)
+                        }
+                        break
+                    }
+                }
+            }
+        }
+        return LowBindingCountMapping(
+            bindings = bindings or other.bindings,
+            terms = terms,
+        )
+    }
+
+    private fun count(other: LowBindingCountMapping): Int {
+        val common = bindings and other.bindings
+        // ensuring all those that are in common, are in fact identical; if there aren't any, no checks are required
+        common.bitIterator().forEach { bindingId ->
+            if (get(bindingId) != other.get(bindingId)) {
+                return -1
+            }
+        }
+        // as all bindings are either not in common, or identical, the total "sum" of these binding pairs is the result
+        return (bindings or other.bindings).countOneBits()
+    }
+
+    private fun get(binding: Int): Int {
+        return terms[bindingIndex(binding)]
+    }
+
+    private fun bindingIndex(target: Int): Int {
+        // ensuring it exists
+        if ((1 shl target) and bindings == 0) {
+            return -1
+        }
+        // method: changing the `bindings` field to only contain all bits lower than our target,
+        //  and counting how many bits of those are set, as every bit set represents a slot (and thus index)
+        //  that should be skipped
+        return (((1 shl target) - 1) and bindings).countOneBits()
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun toString(): String {
+        return "Mapping { bindings: 0x${bindings.toHexString(format = HexFormat { upperCase = true })}, terms: [${terms.joinToString()}] }"
+    }
+
+    override fun hashCode(): Int {
+        return hashCode
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other !is LowBindingCountMapping) {
+            return false
+        }
+        if (hashCode != other.hashCode) {
+            return false
+        }
+        return bindings == other.bindings && terms.contentEquals(other.terms)
+    }
+
+}
+
+private fun Int.bitIterator() = BitIterator(this)
+
+private class BitIterator(private var bits: Int): Iterator<Int> {
+    override fun hasNext(): Boolean {
+        return bits != 0
+    }
+
+    override fun next(): Int {
+        val bit = bits.takeLowestOneBit()
+        val index = bit.countTrailingZeroBits()
+        bits = bits xor bit
+        return index
+    }
+
+    fun remaining(): Int {
+        return bits.countOneBits()
+    }
+}

--- a/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/LowBindingCountMapping.kt
+++ b/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/LowBindingCountMapping.kt
@@ -2,8 +2,9 @@ package dev.tesserakt
 
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.sparql.runtime.evaluation.BindingIdentifier
-import dev.tesserakt.sparql.runtime.evaluation.QueryContext
 import dev.tesserakt.sparql.runtime.evaluation.TermIdentifier
+import dev.tesserakt.sparql.runtime.evaluation.context.QueryContext
+import dev.tesserakt.util.bitIterator
 
 class LowBindingCountMapping private constructor(
     // self-managed bitmask
@@ -161,23 +162,4 @@ class LowBindingCountMapping private constructor(
         return bindings == other.bindings && terms.contentEquals(other.terms)
     }
 
-}
-
-private fun Int.bitIterator() = BitIterator(this)
-
-private class BitIterator(private var bits: Int): Iterator<Int> {
-    override fun hasNext(): Boolean {
-        return bits != 0
-    }
-
-    override fun next(): Int {
-        val bit = bits.takeLowestOneBit()
-        val index = bit.countTrailingZeroBits()
-        bits = bits xor bit
-        return index
-    }
-
-    fun remaining(): Int {
-        return bits.countOneBits()
-    }
 }

--- a/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
+++ b/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
@@ -4,6 +4,7 @@ import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
 import dev.tesserakt.sparql.runtime.evaluation.context.GlobalQueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.BitsetMapping
 import dev.tesserakt.sparql.runtime.evaluation.mapping.IntPairMapping
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.Scope
@@ -46,8 +47,8 @@ class MappingBenchmark {
     private val right = mutableListOf<MapMapping>()
     private lateinit var mapping1left: List<IntPairMapping>
     private lateinit var mapping1right: List<IntPairMapping>
-    private lateinit var mapping2left: List<LowBindingCountMapping>
-    private lateinit var mapping2right: List<LowBindingCountMapping>
+    private lateinit var mapping2left: List<BitsetMapping>
+    private lateinit var mapping2right: List<BitsetMapping>
     private val context = GlobalQueryContext
 
     @Setup
@@ -63,8 +64,8 @@ class MappingBenchmark {
         }
         mapping1left = left.map { IntPairMapping(context, it) }
         mapping1right = right.map { IntPairMapping(context, it) }
-        mapping2left = left.map { LowBindingCountMapping(context, it) }
-        mapping2right = right.map { LowBindingCountMapping(context, it) }
+        mapping2left = left.map { BitsetMapping(context, it) }
+        mapping2right = right.map { BitsetMapping(context, it) }
     }
 
     @Benchmark
@@ -80,7 +81,7 @@ class MappingBenchmark {
     }
 
     @Benchmark
-    fun joinNew2(): List<LowBindingCountMapping> {
+    fun joinNew2(): List<BitsetMapping> {
         return mapping2left.flatMap { l -> mapping2right.mapNotNull { r -> l.join(r) } }
             .also { println("Result size new 2: ${it.size}") }
     }

--- a/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
+++ b/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
@@ -44,8 +44,10 @@ class MappingBenchmark {
 
     private val left = mutableListOf<MapMapping>()
     private val right = mutableListOf<MapMapping>()
-    private lateinit var l: List<Mapping>
-    private lateinit var r: List<Mapping>
+    private lateinit var mapping1left: List<Mapping>
+    private lateinit var mapping1right: List<Mapping>
+    private lateinit var mapping2left: List<LowBindingCountMapping>
+    private lateinit var mapping2right: List<LowBindingCountMapping>
     private val context = GlobalQueryContext
 
     @Setup
@@ -59,8 +61,10 @@ class MappingBenchmark {
                 right.add(new)
             }
         }
-        l = left.map { Mapping(context, it) }
-        r = right.map { Mapping(context, it) }
+        mapping1left = left.map { Mapping(context, it) }
+        mapping1right = right.map { Mapping(context, it) }
+        mapping2left = left.map { LowBindingCountMapping(context, it) }
+        mapping2right = right.map { LowBindingCountMapping(context, it) }
     }
 
     @Benchmark
@@ -71,8 +75,14 @@ class MappingBenchmark {
 
     @Benchmark
     fun joinNew(): List<Mapping> {
-        return l.flatMap { l -> r.mapNotNull { r -> l.join(r) } }
-            .also { println("Result size new: ${it.size}") }
+        return mapping1left.flatMap { l -> mapping1right.mapNotNull { r -> l.join(r) } }
+            .also { println("Result size new 1: ${it.size}") }
+    }
+
+    @Benchmark
+    fun joinNew2(): List<LowBindingCountMapping> {
+        return mapping2left.flatMap { l -> mapping2right.mapNotNull { r -> l.join(r) } }
+            .also { println("Result size new 2: ${it.size}") }
     }
 
 }

--- a/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
+++ b/testing/bench/microbench/src/commonMain/kotlin/dev/tesserakt/MappingBenchmark.kt
@@ -3,8 +3,8 @@ package dev.tesserakt
 import dev.tesserakt.rdf.types.Quad
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
-import dev.tesserakt.sparql.runtime.evaluation.GlobalQueryContext
-import dev.tesserakt.sparql.runtime.evaluation.Mapping
+import dev.tesserakt.sparql.runtime.evaluation.context.GlobalQueryContext
+import dev.tesserakt.sparql.runtime.evaluation.mapping.IntPairMapping
 import kotlinx.benchmark.Benchmark
 import kotlinx.benchmark.Scope
 import kotlinx.benchmark.Setup
@@ -44,8 +44,8 @@ class MappingBenchmark {
 
     private val left = mutableListOf<MapMapping>()
     private val right = mutableListOf<MapMapping>()
-    private lateinit var mapping1left: List<Mapping>
-    private lateinit var mapping1right: List<Mapping>
+    private lateinit var mapping1left: List<IntPairMapping>
+    private lateinit var mapping1right: List<IntPairMapping>
     private lateinit var mapping2left: List<LowBindingCountMapping>
     private lateinit var mapping2right: List<LowBindingCountMapping>
     private val context = GlobalQueryContext
@@ -61,8 +61,8 @@ class MappingBenchmark {
                 right.add(new)
             }
         }
-        mapping1left = left.map { Mapping(context, it) }
-        mapping1right = right.map { Mapping(context, it) }
+        mapping1left = left.map { IntPairMapping(context, it) }
+        mapping1right = right.map { IntPairMapping(context, it) }
         mapping2left = left.map { LowBindingCountMapping(context, it) }
         mapping2right = right.map { LowBindingCountMapping(context, it) }
     }
@@ -74,7 +74,7 @@ class MappingBenchmark {
     }
 
     @Benchmark
-    fun joinNew(): List<Mapping> {
+    fun joinNew(): List<IntPairMapping> {
         return mapping1left.flatMap { l -> mapping1right.mapNotNull { r -> l.join(r) } }
             .also { println("Result size new 1: ${it.size}") }
     }

--- a/utils/src/commonJvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.commonJvm.kt
+++ b/utils/src/commonJvmMain/kotlin/dev/tesserakt/util/CollectionExtensions.commonJvm.kt
@@ -1,0 +1,10 @@
+package dev.tesserakt.util
+
+actual inline fun IntArray.cloneTo(
+    target: IntArray,
+    thisOffset: Int,
+    targetOffset: Int,
+    length: Int
+) {
+    System.arraycopy(this, thisOffset, target, targetOffset, length)
+}

--- a/utils/src/commonMain/kotlin/dev/tesserakt/util/Bits.kt
+++ b/utils/src/commonMain/kotlin/dev/tesserakt/util/Bits.kt
@@ -1,0 +1,22 @@
+package dev.tesserakt.util
+
+
+fun Int.bitIterator() = BitIterator(this)
+
+class BitIterator(private var bits: Int): Iterator<Int> {
+    override fun hasNext(): Boolean {
+        return bits != 0
+    }
+
+    override fun next(): Int {
+        val bit = bits.takeLowestOneBit()
+        val index = bit.countTrailingZeroBits()
+        bits = bits xor bit
+        return index
+    }
+
+    fun remaining(): Int {
+        return bits.countOneBits()
+    }
+
+}

--- a/utils/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
+++ b/utils/src/commonMain/kotlin/dev/tesserakt/util/CollectionExtensions.kt
@@ -173,3 +173,5 @@ expect inline fun <T> MutableList<T>.removeFirstElement(): T
  *  Android 14 and below
  */
 expect inline fun <T> MutableList<T>.removeLastElement(): T
+
+expect inline fun IntArray.cloneTo(target: IntArray, thisOffset: Int, targetOffset: Int, length: Int)

--- a/utils/src/jsMain/kotlin/dev/tesserakt/util/CollectionExtensions.js.kt
+++ b/utils/src/jsMain/kotlin/dev/tesserakt/util/CollectionExtensions.js.kt
@@ -19,3 +19,16 @@ actual inline fun <T> MutableList<T>.removeFirstElement(): T {
 actual inline fun <T> MutableList<T>.removeLastElement(): T {
     return removeLast()
 }
+
+actual inline fun IntArray.cloneTo(
+    target: IntArray,
+    thisOffset: Int,
+    targetOffset: Int,
+    length: Int
+) {
+    var i = 0
+    while (i < length) {
+        target[i + targetOffset] = this[i + thisOffset]
+        ++i
+    }
+}

--- a/utils/src/nativeMain/kotlin/dev/tesserakt/util/CollectionExtensions.native.kt
+++ b/utils/src/nativeMain/kotlin/dev/tesserakt/util/CollectionExtensions.native.kt
@@ -19,3 +19,16 @@ actual inline fun <T> MutableList<T>.removeFirstElement(): T {
 actual inline fun <T> MutableList<T>.removeLastElement(): T {
     return removeLast()
 }
+
+actual inline fun IntArray.cloneTo(
+    target: IntArray,
+    thisOffset: Int,
+    targetOffset: Int,
+    length: Int
+) {
+    var i = 0
+    while (i < length) {
+        target[i + targetOffset] = this[i + thisOffset]
+        ++i
+    }
+}

--- a/utils/src/wasmJsMain/kotlin/dev/tesserakt/util/CollectionExtensions.wasmJs.kt
+++ b/utils/src/wasmJsMain/kotlin/dev/tesserakt/util/CollectionExtensions.wasmJs.kt
@@ -19,3 +19,16 @@ actual inline fun <T> MutableList<T>.removeFirstElement(): T {
 actual inline fun <T> MutableList<T>.removeLastElement(): T {
     return removeLast()
 }
+
+actual inline fun IntArray.cloneTo(
+    target: IntArray,
+    thisOffset: Int,
+    targetOffset: Int,
+    length: Int
+) {
+    var i = 0
+    while (i < length) {
+        target[i + targetOffset] = this[i + thisOffset]
+        ++i
+    }
+}


### PR DESCRIPTION
Adds a new mapping implementation using a bitset to represent occupied binding values in query evaluations containing less than 32 distinct binding names.
This MR turns the mapping type into an interface, making different implementations possible, such as this new bitset-based mapping type in compatible queries. The mapping implementation selection is done by the active query context. A new query context using the new bitset-based mapping type is automatically created when possible through a new query context factory method.

Resolves #77 