### PR TITLE
Language term support

### DIFF
--- a/interop/jena/src/jvmMain/kotlin/dev/tesserakt/interop/jena/Extensions.kt
+++ b/interop/jena/src/jvmMain/kotlin/dev/tesserakt/interop/jena/Extensions.kt
@@ -64,10 +64,16 @@ private fun Quad.NamedTerm.asRDFDataType(): RDFDatatype = when (this) {
 
 fun Node.toTerm() : Quad.Element = when (this) {
     is Node_URI -> Quad.NamedTerm(value = uri)
-    is Node_Literal -> Quad.Literal(
-        value = literalValue.toString(),
-        type = literalDatatype.uri.asNamedTerm()
-    )
+    is Node_Literal -> when {
+        literalLanguage.isNotBlank() -> Quad.LangString(
+            value = literalValue.toString(),
+            language = literalLanguage
+        )
+        else -> Quad.Literal(
+            value = literalValue.toString(),
+            type = literalDatatype.uri.asNamedTerm()
+        )
+    }
     is Node_Blank -> Quad.BlankTerm(id = blankNodeLabel.takeLastWhile { it.isDigit() }.toInt())
     else -> throw IllegalArgumentException("Unknown node type `${this::class.simpleName}`")
 }

--- a/interop/jena/src/jvmMain/kotlin/dev/tesserakt/interop/jena/Extensions.kt
+++ b/interop/jena/src/jvmMain/kotlin/dev/tesserakt/interop/jena/Extensions.kt
@@ -44,6 +44,7 @@ fun Quad.Predicate.toJenaTerm() = when (this) {
 fun Quad.Object.toJenaTerm() = when (this) {
     is Quad.NamedTerm -> NodeFactory.createURI(value)
     is Quad.Literal -> NodeFactory.createLiteral(value, type.asRDFDataType())
+    is Quad.LangString -> NodeFactory.createLiteralLang(value, language)
     is Quad.BlankTerm -> NodeFactory.createBlankNode(value)
 }
 

--- a/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
+++ b/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
@@ -78,7 +78,10 @@ fun N3Term.toTerm(): Quad.Element = when (termType) {
 
 fun N3NamedNode.toTerm() = Quad.NamedTerm(value = value)
 
-fun N3Literal.toTerm() = Quad.Literal(value = value, type = datatype.toTerm())
+fun N3Literal.toTerm() = when {
+    language.isNotBlank() -> Quad.LangString(value = value, language = language)
+    else -> Quad.Literal(value = value, type = datatype.toTerm())
+}
 
 fun N3BlankNode.toTerm() = Quad.BlankTerm(id = value.takeLastWhile { it.isDigit() }.toInt())
 

--- a/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
+++ b/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/Extensions.kt
@@ -22,6 +22,7 @@ fun Quad.toN3Triple() = N3Quad(
 fun Quad.Element.toN3Term() = when (this) {
     is Quad.NamedTerm -> createN3NamedNode(value)
     is Quad.Literal -> createN3Literal(value, createN3MappedLiteralDType(type))
+    is Quad.LangString -> createN3Literal(value, language)
     is Quad.BlankTerm -> createN3BlankNode("_:b_$id")
     Quad.DefaultGraph -> DefaultN3Graph
 }

--- a/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/n3/DataFactory.kt
+++ b/interop/rdfjs/src/jsMain/kotlin/dev/tesserakt/interop/rdfjs/n3/DataFactory.kt
@@ -10,4 +10,4 @@ internal external fun createN3BlankNode(value: String): N3BlankNode
 internal external fun createN3NamedNode(value: String): N3NamedNode
 
 @JsName("literal")
-internal external fun createN3Literal(value: Any, type: N3NamedNode = definedExternally): N3Literal
+internal external fun createN3Literal(value: Any, type: Any = definedExternally): N3Literal

--- a/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/Quad.kt
+++ b/rdf/src/commonMain/kotlin/dev/tesserakt/rdf/types/Quad.kt
@@ -1,5 +1,6 @@
 package dev.tesserakt.rdf.types
 
+import dev.tesserakt.rdf.ontology.RDF
 import dev.tesserakt.rdf.ontology.XSD
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmStatic
@@ -44,6 +45,17 @@ data class Quad(
     ): Object {
         override fun toString(): String {
             return "\"$value\"^^${type.value}"
+        }
+    }
+
+    data class LangString(
+        override val value: String,
+        val language: String,
+    ): Object {
+        val type: NamedTerm
+            get() = RDF.langString
+        override fun toString(): String {
+            return "\"$value\"@$language"
         }
     }
 

--- a/serialization/n-triples/src/commonMain/kotlin/dev/tesserakt/rdf/serialization/NTriples.kt
+++ b/serialization/n-triples/src/commonMain/kotlin/dev/tesserakt/rdf/serialization/NTriples.kt
@@ -27,6 +27,7 @@ object NTriples: Serializer() {
         return when (this) {
             is Quad.BlankTerm -> "_:b$id"
             is Quad.Literal -> toString()
+            is Quad.LangString -> toString()
             is Quad.NamedTerm -> "<$value>"
             Quad.DefaultGraph -> throw IllegalStateException("Graph terms (including default graph) are not encoded in the N-Triples format!")
         }

--- a/serialization/n3/src/commonMain/kotlin/dev/tesserakt/rdf/n3/serialization/N3Serializer.kt
+++ b/serialization/n3/src/commonMain/kotlin/dev/tesserakt/rdf/n3/serialization/N3Serializer.kt
@@ -61,6 +61,10 @@ object N3Serializer {
             is dev.tesserakt.rdf.types.Quad.Literal ->
                 N3Token.LiteralTerm(value = value, type = type.tokenized() as N3Token.NonLiteralTerm)
 
+            is dev.tesserakt.rdf.types.Quad.LangString ->
+                // FIXME
+                N3Token.LiteralTerm(value = value, type = type.tokenized() as N3Token.NonLiteralTerm)
+
             is dev.tesserakt.rdf.types.Quad.NamedTerm ->
                 N3Token.Term(value = value)
 

--- a/serialization/trig/src/commonMain/kotlin/dev/tesserakt/rdf/trig/serialization/Deserializer.kt
+++ b/serialization/trig/src/commonMain/kotlin/dev/tesserakt/rdf/trig/serialization/Deserializer.kt
@@ -569,8 +569,7 @@ internal class Deserializer(
             }
 
             is TriGToken.LocalizedLiteralTerm -> {
-                // FIXME
-                Quad.Literal(value = term.value, type = RDF.langString)
+                Quad.LangString(value = term.value, language = term.language)
             }
 
             is TriGToken.PrefixedTerm -> {

--- a/serialization/trig/src/commonMain/kotlin/dev/tesserakt/rdf/trig/serialization/TokenEncoder.kt
+++ b/serialization/trig/src/commonMain/kotlin/dev/tesserakt/rdf/trig/serialization/TokenEncoder.kt
@@ -199,6 +199,7 @@ internal class TokenEncoder(
         is Quad.NamedTerm -> TriGToken.Term(value = value)
         is Quad.BlankTerm -> TriGToken.PrefixedTerm(prefix = "_", value = "b$id")
         is Quad.Literal -> TriGToken.LiteralTerm(value = value, type = TriGToken.Term(value = type.value))
+        is Quad.LangString -> TriGToken.LocalizedLiteralTerm(value = value, language = language)
     }
 
     private fun Quad.Graph.toGraphToken(): TriGToken = when (this) {

--- a/serialization/turtle/src/commonMain/kotlin/dev/tesserakt/rdf/turtle/serialization/Deserializer.kt
+++ b/serialization/turtle/src/commonMain/kotlin/dev/tesserakt/rdf/turtle/serialization/Deserializer.kt
@@ -521,8 +521,7 @@ internal class Deserializer(
             }
 
             is TurtleToken.LocalizedLiteralTerm -> {
-                // FIXME
-                Quad.Literal(value = term.value, type = RDF.langString)
+                Quad.LangString(value = term.value, language = term.language)
             }
 
             is TurtleToken.PrefixedTerm -> {

--- a/serialization/turtle/src/commonMain/kotlin/dev/tesserakt/rdf/turtle/serialization/TokenEncoder.kt
+++ b/serialization/turtle/src/commonMain/kotlin/dev/tesserakt/rdf/turtle/serialization/TokenEncoder.kt
@@ -153,6 +153,7 @@ internal class TokenEncoder(
         is Quad.NamedTerm -> TurtleToken.Term(value = value)
         is Quad.BlankTerm -> TurtleToken.PrefixedTerm(prefix = "_", value = "b$id")
         is Quad.Literal -> TurtleToken.LiteralTerm(value = value, type = TurtleToken.Term(value = type.value))
+        is Quad.LangString -> TurtleToken.LocalizedLiteralTerm(value = value, language = language)
     }
 
 }

--- a/sparql/debugging/src/commonMain/kotlin/dev/tesserakt/sparql/debug/QueryWriter.kt
+++ b/sparql/debugging/src/commonMain/kotlin/dev/tesserakt/sparql/debug/QueryWriter.kt
@@ -83,7 +83,8 @@ abstract class QueryWriter<RT> {
                 add(Token.Binding(element.name))
 
             is TriplePattern.Exact -> when (element.term) {
-                is Quad.Literal -> add(Token.StringLiteral(element.term.value))
+                is Quad.Literal -> add(Token.StringLiteral(element.term.value)) // FIXME - no datatype
+                is Quad.LangString -> add(Token.StringLiteral(element.term.value)) // FIXME - no language tag
                 is Quad.NamedTerm -> add(Token.Term(element.term.value))
                 is Quad.BlankTerm -> throw UnsupportedOperationException()
                 Quad.DefaultGraph -> throw UnsupportedOperationException()

--- a/sparql/debugging/src/commonMain/kotlin/dev/tesserakt/sparql/debug/Util.kt
+++ b/sparql/debugging/src/commonMain/kotlin/dev/tesserakt/sparql/debug/Util.kt
@@ -24,6 +24,12 @@ inline fun Quad.Element.toStylisedString(): StylisedString = when (this) {
         add("\"^^")
         add(type.value, Color.WHITE)
     }
+    is Quad.LangString -> buildStylisedString {
+        add('"')
+        add(value, Color.BRIGHT_GREEN)
+        add("\"@")
+        add(language, Color.WHITE)
+    }
     is Quad.NamedTerm -> value.stylise(Color.BRIGHT_BLUE)
     Quad.DefaultGraph -> StylisedString()
 }

--- a/testing/bench/sparql/core/src/commonMain/kotlin/dev/tesserakt/benchmarking/Self.kt
+++ b/testing/bench/sparql/core/src/commonMain/kotlin/dev/tesserakt/benchmarking/Self.kt
@@ -44,6 +44,7 @@ private val Quad.Element.checksumLength: Int
     get() = when (this) {
         is Quad.BlankTerm -> id.toString().length
         is Quad.Literal -> value.length
+        is Quad.LangString -> value.length
         is Quad.NamedTerm -> value.length
         Quad.DefaultGraph -> 0
     }


### PR DESCRIPTION
Added language term support to the RDF data model for the Object type, which is a specialisation of the general Literal type, having a dedicated Language field present. The interop modules have been expanded to seamlessly map between their language type representations and the new language type introduced in this MR, and the serialization modules have been expanded to properly use the language tag representation.