### PR TITLE
Regular SPARQL endpoint implementation

### DIFF
--- a/sparql/endpoint/cli/README.md
+++ b/sparql/endpoint/cli/README.md
@@ -17,7 +17,8 @@ With the JAR file ready, the server can be started through the commandline. The 
 Usage: java -jar sparql-endpoint.jar [<options>]
 
 Options:
-  --slug=<text>  The name of the endpoint
-  --port=<int>   The port number
-  -h, --help     Show this message and exit
+  --path=<text>    The name of the endpoint
+  --port=<int>     The port number
+  --disable-cache  Disables the use of in-memory query caches
+  -h, --help       Show this message and exit
 ```

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
@@ -1,15 +1,33 @@
 package dev.tesserakt.sparql.endpoint.server
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 
 class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand(), EndpointConfig {
 
-    override val slug: String by option().default("sparql").help("The name of the endpoint")
-    override val port: Int by option().int().default(3000).help("The port number")
+    override fun help(context: Context): String {
+        return "Create a tesserakt-powered SPARQL endpoint from the command line"
+    }
+
+    override val path: String by option()
+        .default("sparql")
+        .help("The name of the endpoint")
+
+    override val port: Int by option()
+        .int()
+        .default(3000)
+        .help("The port number")
+
+    private val disableCache by option()
+        .flag(default = false, defaultForHelp = "cache enabled")
+        .help("Disables the use of in-memory query caches")
+
+    override val useCaching: Boolean get() = !disableCache
 
     override fun run() {
         run(this)

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
@@ -8,17 +8,17 @@ import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 
-class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand(), EndpointConfig {
+class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand() {
 
     override fun help(context: Context): String {
         return "Create a tesserakt-powered SPARQL endpoint from the command line"
     }
 
-    override val path: String by option()
+    private val path: String by option()
         .default("sparql")
         .help("The name of the endpoint")
 
-    override val port: Int by option()
+    private val port: Int by option()
         .int()
         .default(3000)
         .help("The port number")
@@ -27,10 +27,14 @@ class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand(),
         .flag(default = false, defaultForHelp = "cache enabled")
         .help("Disables the use of in-memory query caches")
 
-    override val useCaching: Boolean get() = !disableCache
-
     override fun run() {
-        run(this)
+        run(toConfig())
     }
+
+    private fun toConfig(): EndpointConfig = EndpointConfig(
+        port = port,
+        path = path,
+        useCaching = !disableCache,
+    )
 
 }

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/EndpointConfig.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/EndpointConfig.kt
@@ -2,5 +2,6 @@ package dev.tesserakt.sparql.endpoint.server
 
 interface EndpointConfig {
     val port: Int
-    val slug: String
+    val path: String
+    val useCaching: Boolean
 }

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/EndpointConfig.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/EndpointConfig.kt
@@ -1,7 +1,11 @@
 package dev.tesserakt.sparql.endpoint.server
 
-interface EndpointConfig {
-    val port: Int
-    val path: String
+data class EndpointConfig(
+    val port: Int,
+    val path: String,
     val useCaching: Boolean
+) {
+
+    override fun toString() = "port=$port, path=$path, cache=${if (useCaching) "enabled" else "disabled"}"
+
 }

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Server.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Server.kt
@@ -14,6 +14,7 @@ import io.ktor.server.routing.*
 class Server(config: EndpointConfig) {
 
     private val server = embeddedServer(Netty, port = config.port) {
+        println("Initialising server with configuration $config")
         install(StatusPages) {
             exception<Throwable> { call: ApplicationCall, cause: Throwable ->
                 log(call, cause)
@@ -28,6 +29,7 @@ class Server(config: EndpointConfig) {
     }
 
     fun run() {
+        println("Starting server...")
         server.start(wait = true)
     }
 

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Server.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Server.kt
@@ -1,5 +1,9 @@
 package dev.tesserakt.sparql.endpoint.server
 
+import dev.tesserakt.rdf.types.factory.MutableStore
+import dev.tesserakt.rdf.types.factory.ObservableStore
+import dev.tesserakt.sparql.endpoint.server.impl.CachingSparqlEndpoint
+import dev.tesserakt.sparql.endpoint.server.impl.SparqlEndpoint
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
@@ -16,7 +20,10 @@ class Server(config: EndpointConfig) {
             }
         }
         routing {
-            sparqlEndpoint(config.slug)
+            sparqlEndpoint(
+                path = config.path,
+                endpoint = if (config.useCaching) CachingSparqlEndpoint(ObservableStore()) else SparqlEndpoint(MutableStore())
+            )
         }
     }
 

--- a/sparql/endpoint/ktor/server/README.md
+++ b/sparql/endpoint/ktor/server/README.md
@@ -19,5 +19,5 @@ routing {
 ### Endpoint configuration
 Various configuration options are available to fine-tune the created SPARQL endpoint.
 * `path` (String) - the path name under which the endpoint is registered
-* `store` (ObservableStore) - the store instance that should be used to evaluate SELECT and UPDATE queries. This method does **NOT** create a copy!
+* `endpoint` (SparqlEndpoint) - the endpoint instance that should be used to evaluate SELECT and UPDATE queries. A caching variant is available, which reuses query results as much as possible.
 * `json` (Json) - the serializer used to create the serialized representation of binding results

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.endpoint.server
 
 import dev.tesserakt.sparql.endpoint.core.SparqlContentType
 import dev.tesserakt.sparql.endpoint.core.data.SelectResponse
-import dev.tesserakt.sparql.endpoint.server.impl.SparqlEndpoint
+import dev.tesserakt.sparql.endpoint.server.impl.CachingSparqlEndpoint
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
@@ -22,7 +22,7 @@ fun Route.sparqlEndpoint(
     /** The path name used to make this endpoint available **/
     path: String = "sparql",
     /** The actual [SparqlEndpoint] instance, responsible for processing the requests **/
-    endpoint: SparqlEndpoint = SparqlEndpoint(),
+    endpoint: SparqlEndpoint = CachingSparqlEndpoint(),
     /** The used [Json] instance to serialize binding results with **/
     json: Json = Json,
 ) {

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
@@ -1,7 +1,5 @@
 package dev.tesserakt.sparql.endpoint.server
 
-import dev.tesserakt.rdf.types.ObservableStore
-import dev.tesserakt.rdf.types.factory.ObservableStore
 import dev.tesserakt.sparql.endpoint.core.SparqlContentType
 import dev.tesserakt.sparql.endpoint.core.data.SelectResponse
 import dev.tesserakt.sparql.endpoint.server.impl.SparqlEndpoint
@@ -21,15 +19,13 @@ import kotlinx.serialization.json.encodeToStream
  *  using the [json] parameter.
  */
 fun Route.sparqlEndpoint(
-    /** The path name used to make this endpoint available. **/
+    /** The path name used to make this endpoint available **/
     path: String = "sparql",
-    /** The to-be-observed store, used to evaluate SELECT and UPDATE queries. **/
-    store: ObservableStore = ObservableStore(),
-    /** The used [Json] instance to serialize binding results with. **/
+    /** The actual [SparqlEndpoint] instance, responsible for processing the requests **/
+    endpoint: SparqlEndpoint = SparqlEndpoint(),
+    /** The used [Json] instance to serialize binding results with **/
     json: Json = Json,
 ) {
-    val endpoint = SparqlEndpoint(store)
-
     get(path) {
         val query = call.parameters["query"] ?: run {
             call.respond(

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/CachingSparqlEndpointImpl.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/CachingSparqlEndpointImpl.kt
@@ -12,20 +12,30 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 
-internal class CachingSparqlEndpointImpl(private val store: ObservableStore) : SparqlEndpoint {
+internal class CachingSparqlEndpointImpl(
+    /**
+     * The store that contains the quads. Updates received by this endpoint are reflected in this instance.
+     *
+     * This store instance is observable. This property is used to keep query caches up-to-date, allowing changes to
+     *  propagate to these caches upon query re-execution.
+     */
+    private val store: ObservableStore,
+    /**
+     * The lock guarding the [store] field. When interacting with the store directly, the lock should be held by the
+     *  interacting coroutine.
+     *
+     * If the [store] is expected to be mutated outside of this endpoint, a shared lock should be passed as an argument,
+     *  ensuring the endpoint and the external logic does not mutate the store at the same time.
+     */
+    // could be a RW lock, but doesn't seem to exist in coroutines (yet)
+    private val storeLock: Mutex = Mutex(),
+) : SparqlEndpoint {
 
     /**
      * The lock guarding the [queryCache] field. When interacting with the map itself, or with any evaluation found
      *  inside the map, the lock should be held by the interacting coroutine.
      */
     private val queryCacheLock = Mutex()
-
-    /**
-     * The lock guarding the [store] field. When interacting with the store directly, the lock should be held by the
-     *  interacting coroutine.
-     */
-    // could be a RW lock, but doesn't seem to exist in coroutines (yet)
-    private val storeLock = Mutex()
 
     private val queryCache = mutableMapOf<Query<Bindings>, DeferredOngoingQueryEvaluation<Bindings>>()
 

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/CachingSparqlEndpointImpl.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/CachingSparqlEndpointImpl.kt
@@ -1,0 +1,68 @@
+package dev.tesserakt.sparql.endpoint.server.impl
+
+import dev.tesserakt.rdf.types.ObservableStore
+import dev.tesserakt.sparql.Bindings
+import dev.tesserakt.sparql.Query
+import dev.tesserakt.sparql.endpoint.core.data.SelectResponse
+import dev.tesserakt.sparql.endpoint.core.data.UpdateRequest
+import dev.tesserakt.sparql.endpoint.server.SparqlEndpoint
+import dev.tesserakt.sparql.evaluation.DeferredOngoingQueryEvaluation
+import dev.tesserakt.sparql.queryDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+
+internal class CachingSparqlEndpointImpl(private val store: ObservableStore) : SparqlEndpoint {
+
+    /**
+     * The lock guarding the [queryCache] field. When interacting with the map itself, or with any evaluation found
+     *  inside the map, the lock should be held by the interacting coroutine.
+     */
+    private val queryCacheLock = Mutex()
+
+    /**
+     * The lock guarding the [store] field. When interacting with the store directly, the lock should be held by the
+     *  interacting coroutine.
+     */
+    // could be a RW lock, but doesn't seem to exist in coroutines (yet)
+    private val storeLock = Mutex()
+
+    private val queryCache = mutableMapOf<Query<Bindings>, DeferredOngoingQueryEvaluation<Bindings>>()
+
+    override suspend fun onSelectQueryRequest(query: String): Result<SelectResponse> = runCatching {
+        val compiled = Query.Select(query)
+        // the entire query evaluation logic has to be put behind the lock, as it's possible for two concurrent
+        //  requests targeting the same cached query to update the deferred results otherwise
+        queryCacheLock.withLock {
+            val evaluation = queryCache.getOrPut(compiled) {
+                // as we're creating a new query state from scratch, we're required to lock the underlying store,
+                //  as the data is being added to the queue
+                storeLock.withLock {
+                    store.queryDeferred(compiled)
+                }
+            }
+            SelectResponse(compiled, evaluation)
+        }
+    }
+
+    override suspend fun onUpdateQueryRequest(query: String): Result<Unit> = runCatching {
+        val request = UpdateRequest.parse(query)
+        if (request.additions.isEmpty() && request.deletions.isEmpty()) {
+            // early bailout - no locks required
+            return@runCatching
+        }
+        storeLock.withLock {
+            store.addAll(request.additions)
+            store.removeAll(request.deletions)
+            // small optimisation: if the UPDATE causes all data to be removed, it's much faster to clear
+            //  any existing, outdated, queries and re-evaluate them from scratch than it is to
+            //  first process all deletions from the outdated state
+            if (store.isEmpty()) {
+                queryCacheLock.withLock {
+                    queryCache.clear()
+                }
+            }
+        }
+    }
+
+}

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SelectResponseFactory.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SelectResponseFactory.kt
@@ -7,7 +7,7 @@ import dev.tesserakt.sparql.endpoint.core.data.SelectResponse.Results.Companion.
 import dev.tesserakt.sparql.evaluation.DeferredOngoingQueryEvaluation
 import dev.tesserakt.sparql.variables
 
-fun SelectResponse(query: Query<Bindings>, evaluation: DeferredOngoingQueryEvaluation<Bindings>): SelectResponse {
+internal fun SelectResponse(query: Query<Bindings>, evaluation: DeferredOngoingQueryEvaluation<Bindings>): SelectResponse {
     return SelectResponse(
         head = SelectResponse.Head(
             variables = query.variables
@@ -18,7 +18,7 @@ fun SelectResponse(query: Query<Bindings>, evaluation: DeferredOngoingQueryEvalu
     )
 }
 
-fun SelectResponse(query: Query<Bindings>, results: Collection<Bindings>): SelectResponse {
+internal fun SelectResponse(query: Query<Bindings>, results: Collection<Bindings>): SelectResponse {
     return SelectResponse(
         head = SelectResponse.Head(
             variables = query.variables

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SelectResponseFactory.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SelectResponseFactory.kt
@@ -17,3 +17,14 @@ fun SelectResponse(query: Query<Bindings>, evaluation: DeferredOngoingQueryEvalu
         )
     )
 }
+
+fun SelectResponse(query: Query<Bindings>, results: Collection<Bindings>): SelectResponse {
+    return SelectResponse(
+        head = SelectResponse.Head(
+            variables = query.variables
+        ),
+        results = SelectResponse.Results(
+            bindings = results.map { it.associate { it.first to it.second.encoded() } }
+        )
+    )
+}

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointFactory.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointFactory.kt
@@ -1,7 +1,20 @@
 package dev.tesserakt.sparql.endpoint.server.impl
 
+import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.ObservableStore
 import dev.tesserakt.rdf.types.factory.ObservableStore
 import dev.tesserakt.sparql.endpoint.server.SparqlEndpoint
+import kotlinx.coroutines.sync.Mutex
 
-fun SparqlEndpoint(store: ObservableStore = ObservableStore()): SparqlEndpoint = SparqlEndpointImpl(store)
+fun SparqlEndpoint(store: ObservableStore = ObservableStore()): SparqlEndpoint = CachingSparqlEndpointImpl(store)
+
+/**
+ * Creates a [SparqlEndpoint] instance backed by a [MutableStore]. As the instance does not allow for observations, any
+ *  requested query is not cached (changes cannot be detected and so caches cannot be kept up-to-date accordingly).
+ *
+ * @param store The store that contains the quads. Updates received by this endpoint are reflected in this instance.
+ * @param lock The lock guarding the [store] field. When interacting with the store directly, the lock should be held by
+ *  the interacting coroutine. If the [store] is expected to be mutated outside of this endpoint, a shared lock should
+ *  be passed as an argument, ensuring the endpoint and the external logic does not mutate the store at the same time.
+ */
+fun SparqlEndpoint(store: MutableStore, lock: Mutex = Mutex()): SparqlEndpoint = SparqlEndpointImpl(store = store, storeLock = lock)

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointFactory.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointFactory.kt
@@ -6,7 +6,23 @@ import dev.tesserakt.rdf.types.factory.ObservableStore
 import dev.tesserakt.sparql.endpoint.server.SparqlEndpoint
 import kotlinx.coroutines.sync.Mutex
 
-fun SparqlEndpoint(store: ObservableStore = ObservableStore()): SparqlEndpoint = CachingSparqlEndpointImpl(store)
+/**
+ * Creates a [SparqlEndpoint] instance backed by an [ObservableStore]. As the instance allows for observations, caches
+ *  are created for requested queries, with cache updates deferred until getting new requests for the same query.
+ *
+ * @param store The store that contains the quads. Updates received by this endpoint are reflected in this instance.
+ *  This store instance is observable. This property is used to keep query caches up-to-date, allowing changes to
+ *  propagate to these caches upon query re-execution.
+ * @param lock The lock guarding the [store] field. When interacting with the store directly, the lock should be held
+ *  by the interacting coroutine. If the [store] is expected to be mutated outside of this endpoint, a shared lock
+ *  should be passed as an argument, ensuring the endpoint and the external logic does not mutate the store at the same
+ *  time.
+ */
+fun SparqlEndpoint(
+    store: ObservableStore = ObservableStore(),
+    lock: Mutex = Mutex(),
+): SparqlEndpoint =
+    CachingSparqlEndpointImpl(store = store, storeLock = lock)
 
 /**
  * Creates a [SparqlEndpoint] instance backed by a [MutableStore]. As the instance does not allow for observations, any
@@ -17,4 +33,5 @@ fun SparqlEndpoint(store: ObservableStore = ObservableStore()): SparqlEndpoint =
  *  the interacting coroutine. If the [store] is expected to be mutated outside of this endpoint, a shared lock should
  *  be passed as an argument, ensuring the endpoint and the external logic does not mutate the store at the same time.
  */
-fun SparqlEndpoint(store: MutableStore, lock: Mutex = Mutex()): SparqlEndpoint = SparqlEndpointImpl(store = store, storeLock = lock)
+fun SparqlEndpoint(store: MutableStore, lock: Mutex = Mutex()): SparqlEndpoint =
+    SparqlEndpointImpl(store = store, storeLock = lock)

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointFactory.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointFactory.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.sync.Mutex
  *  should be passed as an argument, ensuring the endpoint and the external logic does not mutate the store at the same
  *  time.
  */
-fun SparqlEndpoint(
+fun CachingSparqlEndpoint(
     store: ObservableStore = ObservableStore(),
     lock: Mutex = Mutex(),
 ): SparqlEndpoint =

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointImpl.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/SparqlEndpointImpl.kt
@@ -1,48 +1,37 @@
 package dev.tesserakt.sparql.endpoint.server.impl
 
-import dev.tesserakt.rdf.types.ObservableStore
-import dev.tesserakt.sparql.Bindings
+import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.sparql.Query
 import dev.tesserakt.sparql.endpoint.core.data.SelectResponse
 import dev.tesserakt.sparql.endpoint.core.data.UpdateRequest
 import dev.tesserakt.sparql.endpoint.server.SparqlEndpoint
-import dev.tesserakt.sparql.evaluation.DeferredOngoingQueryEvaluation
-import dev.tesserakt.sparql.queryDeferred
+import dev.tesserakt.sparql.query
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 
-internal class SparqlEndpointImpl(private val store: ObservableStore) : SparqlEndpoint {
-
+internal class SparqlEndpointImpl(
     /**
-     * The lock guarding the [queryCache] field. When interacting with the map itself, or with any evaluation found
-     *  inside the map, the lock should be held by the interacting coroutine.
+     * The store that contains the quads. Updates received by this endpoint are reflected in this instance.
      */
-    private val queryCacheLock = Mutex()
-
+    private val store: MutableStore,
     /**
      * The lock guarding the [store] field. When interacting with the store directly, the lock should be held by the
      *  interacting coroutine.
+     *
+     * If the [store] is expected to be mutated outside of this endpoint, a shared lock should be passed as an argument,
+     *  ensuring the endpoint and the external logic does not mutate the store at the same time.
      */
-    // could be a RW lock, but doesn't seem to exist in coroutines (yet)
-    private val storeLock = Mutex()
-
-    private val queryCache = mutableMapOf<Query<Bindings>, DeferredOngoingQueryEvaluation<Bindings>>()
+    private val storeLock: Mutex = Mutex(),
+) : SparqlEndpoint {
 
     override suspend fun onSelectQueryRequest(query: String): Result<SelectResponse> = runCatching {
         val compiled = Query.Select(query)
-        // the entire query evaluation logic has to be put behind the lock, as it's possible for two concurrent
-        //  requests targeting the same cached query to update the deferred results otherwise
-        queryCacheLock.withLock {
-            val evaluation = queryCache.getOrPut(compiled) {
-                // as we're creating a new query state from scratch, we're required to lock the underlying store,
-                //  as the data is being added to the queue
-                storeLock.withLock {
-                    store.queryDeferred(compiled)
-                }
-            }
-            SelectResponse(compiled, evaluation)
+        // whilst querying, the store should not mutate
+        val results = storeLock.withLock {
+            store.query(compiled)
         }
+        SelectResponse(compiled, results)
     }
 
     override suspend fun onUpdateQueryRequest(query: String): Result<Unit> = runCatching {
@@ -54,14 +43,6 @@ internal class SparqlEndpointImpl(private val store: ObservableStore) : SparqlEn
         storeLock.withLock {
             store.addAll(request.additions)
             store.removeAll(request.deletions)
-            // small optimisation: if the UPDATE causes all data to be removed, it's much faster to clear
-            //  any existing, outdated, queries and re-evaluate them from scratch than it is to
-            //  first process all deletions from the outdated state
-            if (store.isEmpty()) {
-                queryCacheLock.withLock {
-                    queryCache.clear()
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Added a more standard SPARQL endpoint implementation that does not do any query caching. Changed the SPARQL endpoint API to allow these implementations to be chosen during configuration. It's also possible now to set a store lock, in case store changes are being made external to the endpoint logic itself when a store instance is shared.