### PR TITLE
Fix: missing support for UPDATE requests using form parameters

### DIFF
--- a/sparql/endpoint/cli/src/test/kotlin/SparqlEndpointTest.kt
+++ b/sparql/endpoint/cli/src/test/kotlin/SparqlEndpointTest.kt
@@ -1,3 +1,4 @@
+import dev.tesserakt.rdf.dsl.buildStore
 import dev.tesserakt.rdf.types.Quad.Companion.asLiteralTerm
 import dev.tesserakt.rdf.types.Quad.Companion.asNamedTerm
 import dev.tesserakt.sparql.endpoint.client.*
@@ -67,6 +68,38 @@ class SparqlEndpointTest {
                 "user".asNamedTerm() has "name".asNamedTerm() being "Test".asLiteralTerm()
             }
         }
+        assertEquals(HttpStatusCode.OK, insertion.status)
+
+        val select2 = client.sparqlQuery("sparql", selectAll)
+        assertEquals(HttpStatusCode.OK, select2.status)
+        assertContentEquals(
+            expected = listOf(mapOf("s" to "user", "p" to "name", "o" to "Test")),
+            actual = select2.bodyAsBindings().map { it.toMap().mapValues { it.value.value } }
+        )
+    }
+
+    @Test
+    fun insertAndQueryTestAlt() = test { client ->
+        val selectAll = "select * { ?s ?p ?o }"
+
+        val select1 = client.sparqlQuery("sparql", selectAll)
+        assertEquals(select1.status, HttpStatusCode.OK)
+        assert(select1.bodyAsBindings().isEmpty())
+
+        val insertion = client.submitForm(
+            url = "sparql",
+            formParameters = ParametersBuilder()
+                .apply {
+                    append(
+                        name = "update",
+                        value = SparqlUpdateRequestBuilder().apply {
+                            add(buildStore {
+                                "user".asNamedTerm() has "name".asNamedTerm() being "Test".asLiteralTerm()
+                            })
+                        }.toQueryString()
+                    )
+                }.build()
+        )
         assertEquals(HttpStatusCode.OK, insertion.status)
 
         val select2 = client.sparqlQuery("sparql", selectAll)

--- a/sparql/endpoint/ktor/client/src/commonMain/kotlin/dev/tesserakt/sparql/endpoint/client/QueryOperationMode.kt
+++ b/sparql/endpoint/ktor/client/src/commonMain/kotlin/dev/tesserakt/sparql/endpoint/client/QueryOperationMode.kt
@@ -29,7 +29,7 @@ enum class QueryOperationMode(
             path,
             formParameters = parametersOf("query" to listOf(query))
         ) {
-            contentType(SparqlContentType.SelectPostForm)
+            contentType(SparqlContentType.FormPost)
             block()
         }
     }),

--- a/sparql/endpoint/ktor/core/src/commonMain/kotlin/dev/tesserakt/sparql/endpoint/core/SparqlContentType.kt
+++ b/sparql/endpoint/ktor/core/src/commonMain/kotlin/dev/tesserakt/sparql/endpoint/core/SparqlContentType.kt
@@ -5,7 +5,7 @@ import io.ktor.http.*
 
 object SparqlContentType {
 
-    val SelectPostForm = ContentType(contentType = "application", contentSubtype = "x-www-form-urlencoded")
+    val FormPost = ContentType(contentType = "application", contentSubtype = "x-www-form-urlencoded")
     val SelectPostBody = ContentType(contentType = "application", contentSubtype = "sparql-query")
 
     val UpdateQuery = ContentType(contentType = "application", contentSubtype = "sparql-update")

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
@@ -44,16 +44,22 @@ fun Route.sparqlEndpoint(
                 )
                 return@post
             }
-            type.match(SparqlContentType.SelectPostForm) -> {
+            type.match(SparqlContentType.FormPost) -> {
+                // joining the total list of params together, from form parameters & url parameters
                 val params = call.receiveParameters()
-                val query = params["query"] ?: run {
+                if ("query" in params) {
+                    endpoint.onSelectQueryRequest(query = params["query"]!!)
+                } else if ("update" in params) {
+                    val result = endpoint.onUpdateQueryRequest(request = UpdateRequest.parse(params["update"]!!))
+                    call.respond(result) { cause -> "Invalid query! Caught the following exception.\n${cause.message}" }
+                    return@post
+                } else {
                     call.respond(
                         status = HttpStatusCode.BadRequest,
                         message = "No query provided!"
                     )
                     return@post
                 }
-                endpoint.onSelectQueryRequest(query = query)
             }
             type.match(SparqlContentType.SelectPostBody) -> {
                 endpoint.onSelectQueryRequest(query = call.receiveText())


### PR DESCRIPTION
The endpoint server now checks for the presence of "update" in received form parameters, issuing an update callback instead
Renamed SelectPostForm to FormPost, as it can also represent an UPDATE query
Added an extra test, validating form-based UPDATE requests