### PR TITLE
Configurable SPARQL endpoint cache size

### DIFF
--- a/sparql/endpoint/cli/README.md
+++ b/sparql/endpoint/cli/README.md
@@ -14,12 +14,14 @@ After the build has finished, the resulting JAR file can be located in `build/li
 ## CLI
 With the JAR file ready, the server can be started through the commandline. The `-h` flag exposes all available options:
 ```
-Usage: java -jar sparql-endpoint.jar [<options>]
+Usage: tesserakt-endpoint [<options>]
+
+  Create a tesserakt SPARQL endpoint from the command line
 
 Options:
   --path=<text>       The name of the endpoint
   --port=<int>        The port number
-  --disable-cache     Disables the use of in-memory query caches
+  --cache-size=<int>  The number of queries to cache, with 0 being disabled (= default)
   --verbose           Enable additional logging
   --from-file=<path>  Use a dataset as an initial value for the in-memory store (can be N-Triples, Turtle or TriG)
   -h, --help          Show this message and exit

--- a/sparql/endpoint/cli/build.gradle.kts
+++ b/sparql/endpoint/cli/build.gradle.kts
@@ -37,6 +37,6 @@ application {
 
 ktor {
     fatJar {
-        archiveFileName.set("sparql-endpoint.jar")
+        archiveFileName.set("tesserakt-endpoint.jar")
     }
 }

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
@@ -2,10 +2,7 @@ package dev.tesserakt.sparql.endpoint.server
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.help
-import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
 
@@ -24,9 +21,11 @@ class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand() 
         .default(3000)
         .help("The port number")
 
-    private val disableCache by option()
-        .flag(default = false, defaultForHelp = "cache enabled")
-        .help("Disables the use of in-memory query caches")
+    private val cacheSize by option()
+        .int()
+        .default(0)
+        .help("The number of queries to cache, with 0 being disabled (= default)")
+        .check { it >= 0 }
 
     private val verbose by option()
         .flag(default = false)
@@ -43,7 +42,7 @@ class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand() 
     private fun toConfig(): EndpointConfig = EndpointConfig(
         port = port,
         path = path,
-        useCaching = !disableCache,
+        cacheSize = cacheSize,
         verbose = verbose,
         start = start,
     )

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/CliEntryPoint.kt
@@ -6,10 +6,10 @@ import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
 
-class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand() {
+class CliEntryPoint(private val run: (EndpointConfig) -> Unit) : CliktCommand("tesserakt-endpoint") {
 
     override fun help(context: Context): String {
-        return "Create a tesserakt-powered SPARQL endpoint from the command line"
+        return "Create a tesserakt SPARQL endpoint from the command line"
     }
 
     private val path: String by option()

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Endpoint.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Endpoint.kt
@@ -8,8 +8,7 @@ import dev.tesserakt.rdf.types.factory.ObservableStore
 import dev.tesserakt.rdf.types.factory.emptyStore
 import dev.tesserakt.sparql.endpoint.core.data.SelectResponse
 import dev.tesserakt.sparql.endpoint.core.data.UpdateRequest
-import dev.tesserakt.sparql.endpoint.server.impl.CachingSparqlEndpoint
-import dev.tesserakt.sparql.endpoint.server.impl.SparqlEndpoint
+import dev.tesserakt.sparql.endpoint.server.factory.SparqlEndpoint
 
 /**
  * A simple [SparqlEndpoint] decorator, instantiating either a caching or regular endpoint based on the [EndpointConfig]
@@ -22,10 +21,16 @@ class Endpoint(config: EndpointConfig): SparqlEndpoint {
         } else {
             emptyStore()
         }
-        if (!config.useCaching) {
-            SparqlEndpoint(MutableStore(base))
-        } else {
-            CachingSparqlEndpoint(ObservableStore(base))
+        // we can get away with using a simpler 'MutableStore' if no caching is required - the actual updates happening
+        //  are not relevant for anything else
+        when {
+            config.cacheSize > 0 -> {
+                SparqlEndpoint(ObservableStore(base), cacheSize = config.cacheSize)
+            }
+            config.cacheSize == 0 -> {
+                SparqlEndpoint(MutableStore(base))
+            }
+            else -> throw IllegalStateException("Invalid cache configuration!")
         }
     }
 

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/EndpointConfig.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/EndpointConfig.kt
@@ -5,11 +5,28 @@ import java.io.File
 data class EndpointConfig(
     val port: Int,
     val path: String,
-    val useCaching: Boolean,
+    val cacheSize: Int,
     val verbose: Boolean,
     val start: File?,
 ) {
 
-    override fun toString() = "port=$port, path=$path, cache=${if (useCaching) "enabled" else "disabled"}, startFilePath=`${start?.path}`, verbose=$verbose"
+    override fun toString() = buildString {
+        if (verbose) {
+            appendLine("tesserakt - SPARQL endpoint configuration (verbose)")
+        } else {
+            appendLine("tesserakt - SPARQL endpoint configuration")
+        }
+        append("port = ")
+        appendLine(port)
+        append("path = ")
+        appendLine(path)
+        append("cacheSize = ")
+        append(if (cacheSize == 0) "disabled" else cacheSize)
+        if (start != null) {
+            append('\n')
+            append("filepath = ")
+            append(start.absolutePath)
+        }
+    }
 
 }

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Server.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/Server.kt
@@ -9,7 +9,7 @@ import io.ktor.server.routing.*
 class Server(config: EndpointConfig) {
 
     private val server = embeddedServer(Netty, port = config.port) {
-        println("Initialising server with configuration $config")
+        println("Initialising server with configuration\n${config.toString().prependIndent(" | ")}")
         install(StatusPages) {
             exception<Throwable> { call: ApplicationCall, cause: Throwable ->
                 log(call, cause)
@@ -27,7 +27,6 @@ class Server(config: EndpointConfig) {
     }
 
     fun run() {
-        println("Starting server...")
         server.start(wait = true)
     }
 

--- a/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/VerboseEndpoint.kt
+++ b/sparql/endpoint/cli/src/main/kotlin/dev/tesserakt/sparql/endpoint/server/VerboseEndpoint.kt
@@ -10,8 +10,7 @@ import dev.tesserakt.rdf.types.factory.ObservableStore
 import dev.tesserakt.rdf.types.factory.emptyStore
 import dev.tesserakt.sparql.endpoint.core.data.SelectResponse
 import dev.tesserakt.sparql.endpoint.core.data.UpdateRequest
-import dev.tesserakt.sparql.endpoint.server.impl.CachingSparqlEndpoint
-import dev.tesserakt.sparql.endpoint.server.impl.SparqlEndpoint
+import dev.tesserakt.sparql.endpoint.server.factory.SparqlEndpoint
 
 /**
  * A [SparqlEndpoint] decorator, similar to [Endpoint], with the addition of making the various operations more verbose
@@ -31,11 +30,7 @@ class VerboseEndpoint(config: EndpointConfig) : SparqlEndpoint {
         }
         ObservableStore(base)
     }
-    private val inner = if (!config.useCaching) {
-        SparqlEndpoint(store)
-    } else {
-        CachingSparqlEndpoint(store)
-    }
+    private val inner = SparqlEndpoint(store, cacheSize = config.cacheSize)
 
     private var added = 0
     private var deleted = 0

--- a/sparql/endpoint/ktor/server/build.gradle.kts
+++ b/sparql/endpoint/ktor/server/build.gradle.kts
@@ -23,5 +23,10 @@ kotlin {
                 api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
             }
         }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/SparqlEndpointRoute.kt
@@ -2,7 +2,7 @@ package dev.tesserakt.sparql.endpoint.server
 
 import dev.tesserakt.sparql.endpoint.core.SparqlContentType
 import dev.tesserakt.sparql.endpoint.core.data.UpdateRequest
-import dev.tesserakt.sparql.endpoint.server.impl.CachingSparqlEndpoint
+import dev.tesserakt.sparql.endpoint.server.factory.SparqlEndpoint
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
@@ -18,7 +18,7 @@ fun Route.sparqlEndpoint(
     /** The path name used to make this endpoint available **/
     path: String = "sparql",
     /** The actual [SparqlEndpoint] instance, responsible for processing the requests **/
-    endpoint: SparqlEndpoint = CachingSparqlEndpoint(),
+    endpoint: SparqlEndpoint = SparqlEndpoint(),
     /** The used [ResultFormatter] instance to serialize binding results with **/
     formatter: ResultFormatter = ResultFormatter(),
 ) {

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/factory/SparqlEndpointFactory.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/factory/SparqlEndpointFactory.kt
@@ -1,28 +1,35 @@
-package dev.tesserakt.sparql.endpoint.server.impl
+package dev.tesserakt.sparql.endpoint.server.factory
 
 import dev.tesserakt.rdf.types.MutableStore
 import dev.tesserakt.rdf.types.ObservableStore
 import dev.tesserakt.rdf.types.factory.ObservableStore
 import dev.tesserakt.sparql.endpoint.server.SparqlEndpoint
+import dev.tesserakt.sparql.endpoint.server.impl.CachingSparqlEndpointImpl
+import dev.tesserakt.sparql.endpoint.server.impl.SparqlEndpointImpl
 import kotlinx.coroutines.sync.Mutex
 
 /**
  * Creates a [SparqlEndpoint] instance backed by an [ObservableStore]. As the instance allows for observations, caches
- *  are created for requested queries, with cache updates deferred until getting new requests for the same query.
+ *  can be created for requested queries, with cache updates deferred until getting new requests for the same query.
  *
  * @param store The store that contains the quads. Updates received by this endpoint are reflected in this instance.
  *  This store instance is observable. This property is used to keep query caches up-to-date, allowing changes to
  *  propagate to these caches upon query re-execution.
+ * @param cacheSize The number of queries that should be cached (>= 0)
  * @param lock The lock guarding the [store] field. When interacting with the store directly, the lock should be held
  *  by the interacting coroutine. If the [store] is expected to be mutated outside of this endpoint, a shared lock
  *  should be passed as an argument, ensuring the endpoint and the external logic does not mutate the store at the same
  *  time.
  */
-fun CachingSparqlEndpoint(
+fun SparqlEndpoint(
     store: ObservableStore = ObservableStore(),
+    cacheSize: Int = 3,
     lock: Mutex = Mutex(),
-): SparqlEndpoint =
-    CachingSparqlEndpointImpl(store = store, storeLock = lock)
+): SparqlEndpoint = when {
+    cacheSize == 0 -> SparqlEndpointImpl(store = store, storeLock = lock)
+    cacheSize > 0 ->  CachingSparqlEndpointImpl(store = store, storeLock = lock, cacheSize = cacheSize)
+    else ->           throw IllegalArgumentException("A cache size of $cacheSize is invalid (should be >= 0)")
+}
 
 /**
  * Creates a [SparqlEndpoint] instance backed by a [MutableStore]. As the instance does not allow for observations, any

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/CachingSparqlEndpointImpl.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/CachingSparqlEndpointImpl.kt
@@ -29,6 +29,7 @@ internal class CachingSparqlEndpointImpl(
      */
     // could be a RW lock, but doesn't seem to exist in coroutines (yet)
     private val storeLock: Mutex = Mutex(),
+    cacheSize: Int,
 ) : SparqlEndpoint {
 
     /**
@@ -37,7 +38,7 @@ internal class CachingSparqlEndpointImpl(
      */
     private val queryCacheLock = Mutex()
 
-    private val queryCache = mutableMapOf<Query<Bindings>, DeferredOngoingQueryEvaluation<Bindings>>()
+    private val queryCache = LRUCache<Query<Bindings>, DeferredOngoingQueryEvaluation<Bindings>>(cacheSize)
 
     override suspend fun onSelectQueryRequest(query: String): Result<SelectResponse> = runCatching {
         val compiled = Query.Select(query)

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/LRUCache.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/impl/LRUCache.kt
@@ -1,0 +1,9 @@
+package dev.tesserakt.sparql.endpoint.server.impl
+
+// src: https://medium.com/@fasilt/understanding-lru-least-recently-used-cache-in-kotlin-b54c7060e752
+internal class LRUCache<K, V>(private val capacity: Int) : LinkedHashMap<K, V>(capacity, 0.75f, true) {
+
+    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean {
+        return size > capacity
+    }
+}

--- a/sparql/endpoint/ktor/server/src/jvmTest/kotlin/LRUTest.kt
+++ b/sparql/endpoint/ktor/server/src/jvmTest/kotlin/LRUTest.kt
@@ -1,0 +1,39 @@
+
+import dev.tesserakt.sparql.endpoint.server.impl.LRUCache
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class LRUTest {
+
+    @Test
+    fun small() {
+        val cache = LRUCache<Int, String>(3)
+        assert(cache.isEmpty())
+        cache[0] = "0"
+        assert(cache.isNotEmpty())
+        assertEquals("0", cache[0])
+        cache.forEach { (key, value) ->
+            assertEquals(0, key)
+            assertEquals("0", value)
+        }
+    }
+
+    @Test
+    fun eviction() {
+        val cache = LRUCache<Int, String>(3)
+        repeat(10) {
+            cache[it] = it.toString()
+        }
+        assertContains(cache, 7)
+        assertContains(cache, 8)
+        assertContains(cache, 9)
+        repeat(7) {
+            assert(it !in cache)
+        }
+        assertEquals("7", cache[7])
+        assertEquals("8", cache[8])
+        assertEquals("9", cache[9])
+    }
+
+}


### PR DESCRIPTION
Added an LRU cache implementation, which is used in the existing caching SPARQL endpoint implementation, limiting the number of distinct queries that are retained in memory for subsequent requests.
The endpoint CLI has also been improved, changing the cache flag to a cache parameter that sets the cache size (with 0 disabling cache outright), alongside minor formatting improvements.