### PR TITLE
Removing the use of (internal) reflection in endpoint formatting

### DIFF
--- a/sparql/endpoint/ktor/client/src/commonMain/kotlin/dev/tesserakt/sparql/endpoint/client/SparqlBindingsContentConverter.kt
+++ b/sparql/endpoint/ktor/client/src/commonMain/kotlin/dev/tesserakt/sparql/endpoint/client/SparqlBindingsContentConverter.kt
@@ -30,7 +30,7 @@ internal object SparqlBindingsContentConverter : ContentConverter {
         }
         value as SelectResponse
         return TextContent(
-            text = json.encodeToString(value),
+            text = json.encodeToString(SelectResponse.serializer(), value),
             contentType = SparqlContentType.JsonBindings.withCharset(charset),
             status = HttpStatusCode.OK
         )
@@ -47,10 +47,10 @@ internal object SparqlBindingsContentConverter : ContentConverter {
         val response: SelectResponse = if (charset != Charsets.UTF_8) {
             @OptIn(InternalAPI::class)
             val text = charset.newDecoder().decode(input = content.readBuffer)
-            json.decodeFromString(text)
+            json.decodeFromString(SelectResponse.serializer(), text)
         } else {
             @OptIn(ExperimentalSerializationApi::class, InternalAPI::class)
-            json.decodeFromSource(content.readBuffer)
+            json.decodeFromSource(SelectResponse.serializer(), content.readBuffer)
         }
         return if (typeInfo.type == SelectResponse::class) {
             response

--- a/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/ResultFormatter.kt
+++ b/sparql/endpoint/ktor/server/src/jvmMain/kotlin/dev/tesserakt/sparql/endpoint/server/ResultFormatter.kt
@@ -8,6 +8,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToStream
 
@@ -27,7 +28,7 @@ class ResultFormatter(
                 accept.forEach { format ->
                     when {
                         SparqlContentType.JsonBindings.match(format) -> {
-                            respondJson(call, response)
+                            respondJson(call, SelectResponse.serializer(), response)
                             return@fold
                         }
 
@@ -52,12 +53,12 @@ class ResultFormatter(
         )
     }
 
-    private suspend inline fun <reified T> respondJson(call: ApplicationCall, data: T) {
+    private suspend fun <T> respondJson(call: ApplicationCall, serializer: KSerializer<T>, data: T) {
         call.respondBytesWriter(
             contentType = SparqlContentType.JsonBindings.withCharset(Charsets.UTF_8)
         ) {
             @OptIn(ExperimentalSerializationApi::class)
-            json.encodeToStream(data, this.toOutputStream())
+            json.encodeToStream(serializer, data, this.toOutputStream())
         }
     }
 


### PR DESCRIPTION
Changed various uses of the `kotlinx.serialization` library to use non-reflection alternatives, avoiding reflection-related issues that can occur e.g. when using GraalVM